### PR TITLE
Replace embed links in quoted messages with escaped versions (Issue #67)

### DIFF
--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
@@ -123,7 +124,23 @@ namespace DiscordBot.Modules
             }
 
             var messageLink = "https://discordapp.com/channels/" + Context.Guild.Id + "/" + channel.Id + "/" + messageId;
-            var msgContent = message.Content == string.Empty ? "" : message.Content.Truncate(1020);
+
+            var msgContent = message.Content;
+
+            if (msgContent != null)
+            {
+                msgContent = msgContent.Truncate(1020);
+
+                // Searches for embed links such as [Google](https://bing.com/)
+                var regex = new Regex(@"\[([^\[\]\(\)]*)\]\((.*?)\)");
+
+                var matches = regex.Matches(msgContent);
+
+                foreach (var match in matches as IEnumerable<Match>)
+                {
+                    msgContent = msgContent.Replace(match.Value, $"\\{match.Value}");
+                }
+            }
 
             var msgAttachment = string.Empty;
             if (message.Attachments?.Count > 0) msgAttachment = "\t📸";


### PR DESCRIPTION
This fixes #67 by using regex to detect when a embed link is within a quoted message and adding a slash `\` in front to escape it.

**Test message I used:**
<pre>
Quote test:
```cs
public string text = null;
```
[Google](https://bing.com/)

**Bold**
*Italicized*
~~***Bold Italicized Strikethrough***~~

`inline code`

> Quote: This was written by someone else
> Multiline Quote!
> They also had a link! Wow! [Unity](https://www.unrealengine.com/marketplace/en-US/store?randomQueryString=asdfaosuhuoiahotrh984t398t)

||Uh oh. Spoilers!||

Whoa another link: [Bing](https://google.com/)

Image attached below:
</pre>

**Before the change:**
![image](https://user-images.githubusercontent.com/42710136/126234152-6023f27e-a207-4ad6-875a-16391b35ce74.png)

**After the change:**
![image](https://user-images.githubusercontent.com/42710136/126234170-2b627670-bf12-4474-a5d6-48cf94b0748a.png)