### PR TITLE
Replace date string with UnixTimeStamp

### DIFF
--- a/DiscordBot/Extensions/DateExtensions.cs
+++ b/DiscordBot/Extensions/DateExtensions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace DiscordBot.Extensions
+{
+    public static class DateExtensions
+    {
+        public static long ToUnixTimestamp(this DateTime date)
+        {
+            return (long) (date.ToUniversalTime().Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
+        }
+    }
+}

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -15,6 +15,7 @@ using DiscordBot.Settings.Deserialized;
 using DiscordBot.Utils.Attributes;
 using HtmlAgilityPack;
 using Microsoft.Extensions.DependencyInjection;
+using DiscordBot.Extensions;
 
 namespace DiscordBot.Modules
 {
@@ -1024,13 +1025,16 @@ namespace DiscordBot.Modules
 
             // Business as usual
             if (birthdate == default)
+            {
                 await ReplyAsync(
-                        $"Sorry, I couldn't find **{searchName}**'s birthday date. They can add it at https://docs.google.com/forms/d/e/1FAIpQLSfUglZtJ3pyMwhRk5jApYpvqT3EtKmLBXijCXYNwHY-v-lKxQ/viewform ! :stuck_out_tongue_winking_eye: ")
+                        $"Sorry, I couldn't find **{searchName}**'s birthday date. They can add it at https://docs.google.com/forms/d/e/1FAIpQLSfUglZtJ3pyMwhRk5jApYpvqT3EtKmLBXijCXYNwHY-v-lKxQ/viewform !")
                     .DeleteAfterSeconds(30);
+            }
             else
             {
+                var date = birthdate.ToUnixTimestamp();
                 var message =
-                    $"**{searchName}**'s birthdate: __**{birthdate.ToString("dd MMMM yyyy", CultureInfo.InvariantCulture)}**__ " +
+                    $"**{searchName}**'s birthdate: **<t:{date}:D>** " +
                     $"({(int)((DateTime.Now - birthdate).TotalDays / 365)}yo)";
 
                 await ReplyAsync(message).DeleteAfterTime(minutes: 3);


### PR DESCRIPTION
Discord formatted Timestamp.

- Added an extension to get a Unix timestamp from a datetime.
- Remove the :stuck_out_tongue_winking_eye: the bot would do if it couldn't find a users birthday.

![image](https://user-images.githubusercontent.com/8342701/129914400-8f41e619-453c-44d3-b139-630f91562561.png)
