### PR TITLE
Improve !curr

### DIFF
--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -1096,11 +1096,26 @@ namespace DiscordBot.Modules
         {
             from = from.ToUpper();
             to = to.ToUpper();
-
-            // Get USD to fromCurrency rate
-            var fromRate = await _currencyService.GetRate(from);
-            // Get USD to toCurrency rate
-            var toRate = await _currencyService.GetRate(to);
+            
+            double fromRate = -1;
+            double toRate = -1;
+            try
+            {
+                // Get USD to fromCurrency rate
+                fromRate = await _currencyService.GetRate(from);
+                // Get USD to toCurrency rate
+                toRate = await _currencyService.GetRate(to);
+            }
+            catch
+            {
+                var embedBuilder = new EmbedBuilder()
+                    .WithTitle("Currency API Down")
+                    .WithDescription(
+                        "Check [API Status](https://www.currencyconverterapi.com/server-status), and try again in a few minutes.")
+                    .WithColor(Color.Red);
+                await ReplyAsync(embed: embedBuilder.Build()).DeleteAfterSeconds(seconds: 10);
+                return;
+            }
 
             if (!await CurrencyFailedResponse((from, fromRate.Equals(-1)), (from, fromRate.Equals(-1))))
             {
@@ -1116,7 +1131,7 @@ namespace DiscordBot.Modules
         {
             if (from.invalid && to.invalid)
             {
-                await ReplyAsync($"{Context.User.Mention}, {from.name} and {to.name} are invalid currencies or I can't understand them.\nPlease use international currency code (example : **USD** for $, **EUR** for €, **PKR** for pakistani rupee).");
+                await ReplyAsync($"{Context.User.Mention}, {from.name} and {to.name} are invalid currencies or incorrectly used.\nPlease use international currency code (example : **USD** for $, **EUR** for €, **PKR** for pakistani rupee).");
                 return false;
             }
             if (from.invalid)


### PR DESCRIPTION
- Will respond with a small embed informing user if the API doesn't respond. Instead of the old behaviour of silently dying.
- Replaced the ``or I can't understand them`` in favor of ``or incorrectly used`` to reduce the humanization of machines. :kappa:

![image](https://user-images.githubusercontent.com/8342701/129918860-695866a2-c068-46b8-927c-857340459c4f.png)
The embed is deleted after 10 seconds.