### PR TITLE
Fix bug where only compares fail fromRate

### DIFF
--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -1121,7 +1121,7 @@ namespace DiscordBot.Modules
                 return;
             }
 
-            if (!await CurrencyFailedResponse((from, fromRate.Equals(-1)), (from, fromRate.Equals(-1))))
+            if (!await CurrencyFailedResponse((from, fromRate.Equals(-1)), (to, toRate.Equals(-1))))
             {
                 await Context.Message.DeleteAfterSeconds(seconds: 1);
                 return;


### PR DESCRIPTION
- Fix where it only compares if fromRate is -1 twice instead of also checking toRate. (whoops)

This resulted in command of !curr 1 aud usd.

to return negative values since usd doesn't exist and would use value of -1 as ``USD.`` value. Now it will just tell the user that ``USD.`` doesn't exist.