### PR TITLE
Don't re-scold for everyone

### DIFF
--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -61,6 +61,9 @@ namespace DiscordBot.Settings.Deserialized
         public string IPGeolocationAPIKey { get; set; }
 
         public string WeatherAPIKey { get; set; }
+
+        // How long between when the bot will scold a user for trying to ping everyone. Default 6 hours
+        public ulong EveryoneScoldPeriodSeconds { get; set; } = 21600;
     }
 
     #region Role Group Collections

--- a/DiscordBot/Settings/Settings.example.json
+++ b/DiscordBot/Settings/Settings.example.json
@@ -82,6 +82,7 @@
   "closedComplaintCategoryId": "662084543662129175",
   /*Commands Configuration*/
   "wikipediaSearchPage": "https://en.wikipedia.org/w/api.php?action=query&format=json&prop=extracts|info&generator=prefixsearch&redirects=1&converttitles=1&utf8=1&formatversion=2&exchars=750&exintro=1&explaintext=1&exsectionformat=plain&inprop=url&gpslimit=5&gpsprofile=fuzzy&gpssearch=",
+  "EveryoneScoldPeriodSeconds": "21600",
   /*API Keys*/
   "WeatherAPIKey": "" // Key for openweathermap.org
 }


### PR DESCRIPTION
Now will only scold users every X minutes. Default config setup, every 6 hours.

There is no cleanup, but the tiny data held by this dictionary is trivial on our scale.

Resolves #106 