### PR TITLE
Fix !wiki large broken embeds

### DIFF
--- a/DiscordBot/Services/UpdateService.cs
+++ b/DiscordBot/Services/UpdateService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Discord;
@@ -306,6 +307,11 @@ namespace DiscordBot.Services
                         }
                         else
                             page.Extract = page.Extract.Replace("\n", Environment.NewLine);
+
+                        //TODO Not a perfect solution. ``!wiki Quaternion`` and a few other formula pages due to formatting will result a mess without this marked by "displaystyle" currently, so we just sanitize the text if we see that.
+                        // This will also help shrink embeds, but it removes paragraphs as well, making it a wall of text.
+                        if (page.Extract.Contains("displaystyle"))
+                            page.Extract = Regex.Replace(page.Extract, @"\s+", " ");
 
                         return (page.Title + ":", page.Extract, page.FullUrl.ToString());
                     }


### PR DESCRIPTION
``displaystyle`` is in all broken embeds due to additional formatting involved. To get around this, we check the extract for ``displaystyle`` if it is found, we do an excessive sanitize of white space and new lines.

This will make results a block of text and destroy natural paragraphs if any exist. But only for results where this is ran.

Resolves #108 