### PR TITLE
Bot auto create threads after message in certain channels

### DIFF
--- a/DiscordBot/Modules/TicketModule.cs
+++ b/DiscordBot/Modules/TicketModule.cs
@@ -65,13 +65,13 @@ namespace DiscordBot.Modules
                 $"The content of this conversation will stay strictly between you {Context.User.Mention} and the {modRole.Mention}.\n" +
                 "Please stay civil, any insults or offensive language could see you punished.\n" +
                 "Do not ping anyone and wait until a staff member is free to examine your complaint.");
-            await newChannel.SendMessageAsync($"A staff member will be able to close this chat by doing !close.");
+            await newChannel.SendMessageAsync($"A staff member will be able to close this chat by doing `!ticket close`.");
         }
 
         /// <summary>
         ///     Archives the ticket.
         /// </summary>
-        [Command("Close"), Alias("end", "done", "bye", "archive"), Summary("Closes the ticket.")]
+        [Command("Ticket Close"), Alias("Ticket end", "Ticket done", "Ticket archive"), Summary("Closes the ticket.")]
         [RequireModerator]
         public async Task Close()
         {
@@ -103,7 +103,7 @@ namespace DiscordBot.Modules
         /// <summary>
         ///     Delete the ticket.
         /// </summary>
-        [Command("Delete"), Summary("Deletes the ticket.")]
+        [Command("Ticket Delete"), Summary("Deletes the ticket.")]
         [RequireAdmin]
         private async Task Delete()
         {

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -1166,8 +1166,7 @@ namespace DiscordBot.Modules
             await currentThread.ModifyAsync(x =>
             {
                 x.Archived = true;
-                var title = autoTheadConfig.GenerateTitleArchived(Context.User);
-                x.Name = title;
+                x.Name = autoTheadConfig.GenerateTitleArchived(Context.User);
             });
         }
 
@@ -1183,8 +1182,7 @@ namespace DiscordBot.Modules
 
             await currentThread.ModifyAsync(x =>
             {
-                var title = autoTheadConfig.GenerateTitle(Context.User);
-                x.Name = title;
+                x.Name = autoTheadConfig.GenerateTitle(Context.User);
             });
         }
 

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -1168,6 +1168,7 @@ namespace DiscordBot.Modules
             await currentThread.ModifyAsync(x =>
             {
                 x.Archived = true;
+                x.Locked = true;
                 x.Name = newName;
             });
         }

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -1163,10 +1163,12 @@ namespace DiscordBot.Modules
 
             if (autoTheadConfig == null) return;
 
+            var newName = autoTheadConfig.GenerateTitleArchived(Context.User);
+            if (currentThread.Name.Equals(newName)) return;
             await currentThread.ModifyAsync(x =>
             {
                 x.Archived = true;
-                x.Name = autoTheadConfig.GenerateTitleArchived(Context.User);
+                x.Name = newName;
             });
         }
 
@@ -1180,9 +1182,11 @@ namespace DiscordBot.Modules
 
             if (autoTheadConfig == null) return;
 
+            var newName = autoTheadConfig.GenerateTitle(Context.User);
+            if (currentThread.Name.Equals(newName)) return;
             await currentThread.ModifyAsync(x =>
             {
-                x.Name = autoTheadConfig.GenerateTitle(Context.User);
+                x.Name = newName;
             });
         }
 

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -1172,6 +1172,8 @@ namespace DiscordBot.Modules
             });
         }
 
+        // Command disabled as there is a rate limit of 2 channel name update every 10 minutes.
+        /*
         [Command("reopen")]
         [Alias("open")]
         [RequireAutoThreadAuthor]
@@ -1189,6 +1191,7 @@ namespace DiscordBot.Modules
                 x.Name = newName;
             });
         }
+        */
 
         #endregion
     }

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -1173,27 +1173,6 @@ namespace DiscordBot.Modules
             });
         }
 
-        // Command disabled as there is a rate limit of 2 channel name update every 10 minutes.
-        /*
-        [Command("reopen")]
-        [Alias("open")]
-        [RequireAutoThreadAuthor]
-        public async Task ReopenClosedAutoThread()
-        {
-            var currentThread = Context.Message.Channel as SocketThreadChannel;
-            var autoTheadConfig = _settings.AutoThreadChannels.Find(x => currentThread.ParentChannel.Id == x.Id && x.CanArchive);
-
-            if (autoTheadConfig == null) return;
-
-            var newName = autoTheadConfig.GenerateTitle(Context.User);
-            if (currentThread.Name.Equals(newName)) return;
-            await currentThread.ModifyAsync(x =>
-            {
-                x.Name = newName;
-            });
-        }
-        */
-
         #endregion
     }
 }

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -1171,6 +1171,23 @@ namespace DiscordBot.Modules
             });
         }
 
+        [Command("reopen")]
+        [Alias("open")]
+        [RequireAutoThreadAuthor]
+        public async Task ReopenClosedAutoThread()
+        {
+            var currentThread = Context.Message.Channel as SocketThreadChannel;
+            var autoTheadConfig = _settings.AutoThreadChannels.Find(x => currentThread.ParentChannel.Id == x.Id && x.CanArchive);
+
+            if (autoTheadConfig == null) return;
+
+            await currentThread.ModifyAsync(x =>
+            {
+                var title = autoTheadConfig.GenerateTitle(Context.User);
+                x.Name = title;
+            });
+        }
+
         #endregion
     }
 }

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -1153,6 +1153,41 @@ namespace DiscordBot.Modules
             return true;
         }
 
+        [Command("close")]
+        [Alias("archive")]
+        public async Task CloseAutoThread()
+        {
+            try
+            {
+                var currentThread = Context.Message.Channel as SocketThreadChannel;
+                if (currentThread == null) return;
+
+                var messages = await currentThread.GetPinnedMessagesAsync();
+                var firstMessage = messages.LastOrDefault();
+
+                if (firstMessage == null) return;
+
+                if (!firstMessage.MentionedUsers.Any(x => x.Id == Context.User.Id)) return;
+
+                foreach (var AutoThreadChannel in _settings.AutoThreadChannels)
+                {
+                    if (currentThread.ParentChannel.Id == AutoThreadChannel.Id && AutoThreadChannel.CanArchive)
+                    {
+                        await currentThread.ModifyAsync(x =>
+                        {
+                            x.Archived = true;
+                            var title = AutoThreadChannel.GenerateTitleArchived(Context.User);
+                            x.Name = title;
+                        });
+                    }
+                }
+            }
+            catch (Exception err)
+            {
+                Console.Error.WriteLine(err);
+            }
+        }
+
         #endregion
     }
 }

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -1153,6 +1153,10 @@ namespace DiscordBot.Modules
             return true;
         }
 
+        #endregion
+
+        #region AutoThread
+
         [Command("close")]
         [Alias("archive")]
         [RequireAutoThreadAuthor]

--- a/DiscordBot/Preconditions.cs
+++ b/DiscordBot/Preconditions.cs
@@ -63,16 +63,19 @@ namespace DiscordBot
             var currentThread = context.Message.Channel as SocketThreadChannel;
             if (currentThread == null) return await Task.FromResult(PreconditionResult.FromError(string.Empty));
 
+            var settings = services.GetRequiredService<Settings.Deserialized.Settings>();
+            if (!settings.AutoThreadChannels.Any(x => currentThread.ParentChannel.Id == x.Id && x.CanArchive))
+                return await Task.FromResult(PreconditionResult.FromError(string.Empty));
+
+            var user = (SocketGuildUser)context.Message.Author;
+            if (user.GuildPermissions.ManageThreads) return await Task.FromResult(PreconditionResult.FromSuccess());
+
             var messages = await currentThread.GetPinnedMessagesAsync();
             var firstMessage = messages.LastOrDefault();
 
             if (firstMessage == null) return await Task.FromResult(PreconditionResult.FromError(string.Empty));
 
             if (!firstMessage.MentionedUsers.Any(x => x.Id == context.User.Id)) return await Task.FromResult(PreconditionResult.FromError(string.Empty));
-
-            var settings = services.GetRequiredService<Settings.Deserialized.Settings>();
-            if (!settings.AutoThreadChannels.Any(x => currentThread.ParentChannel.Id == x.Id && x.CanArchive))
-                return await Task.FromResult(PreconditionResult.FromError(string.Empty));
 
             return await Task.FromResult(PreconditionResult.FromSuccess());
         }

--- a/DiscordBot/Preconditions.cs
+++ b/DiscordBot/Preconditions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,6 +52,29 @@ namespace DiscordBot
                 .DeleteAfterSeconds(seconds: 8);
             await context.Message.DeleteAfterSeconds(seconds: 4);
             return await Task.FromResult(PreconditionResult.FromError(string.Empty));
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class RequireAutoThreadAuthorAttribute : PreconditionAttribute
+    {
+        public override async Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
+        {
+            var currentThread = context.Message.Channel as SocketThreadChannel;
+            if (currentThread == null) return await Task.FromResult(PreconditionResult.FromError(string.Empty));
+
+            var messages = await currentThread.GetPinnedMessagesAsync();
+            var firstMessage = messages.LastOrDefault();
+
+            if (firstMessage == null) return await Task.FromResult(PreconditionResult.FromError(string.Empty));
+
+            if (!firstMessage.MentionedUsers.Any(x => x.Id == context.User.Id)) return await Task.FromResult(PreconditionResult.FromError(string.Empty));
+
+            var settings = services.GetRequiredService<Settings.Deserialized.Settings>();
+            if (!settings.AutoThreadChannels.Any(x => currentThread.ParentChannel.Id == x.Id && x.CanArchive))
+                return await Task.FromResult(PreconditionResult.FromError(string.Empty));
+
+            return await Task.FromResult(PreconditionResult.FromSuccess());
         }
     }
 }

--- a/DiscordBot/Services/UserService.cs
+++ b/DiscordBot/Services/UserService.cs
@@ -627,11 +627,13 @@ namespace DiscordBot.Services
                 {
                     try
                     {
-                        var author = channel.Guild.GetUser(messageParam.Author.Id);
-                        var authorName = author.Nickname;
-                        if (String.IsNullOrEmpty(authorName)) authorName = author.Username;
-                        var title = $"{AutoThreadChannel.Title} - {authorName}";
-                        await channel.CreateThreadAsync(title, Discord.ThreadType.PublicThread, Discord.ThreadArchiveDuration.OneDay, messageParam);
+                        var title = AutoThreadChannel.GenerateTitle(messageParam.Author);
+                        var thread = await channel.CreateThreadAsync(title, Discord.ThreadType.PublicThread, Discord.ThreadArchiveDuration.OneDay, messageParam);
+                        if (AutoThreadChannel.CanArchive)
+                        {
+                            var message = await thread.SendMessageAsync($"{messageParam.Author.Mention} this is your thread. You can do `!close` to archive it when you're done!");
+                            await message.PinAsync();
+                        }
                     }
                     catch (Exception err)
                     {

--- a/DiscordBot/Services/UserService.cs
+++ b/DiscordBot/Services/UserService.cs
@@ -631,7 +631,7 @@ namespace DiscordBot.Services
                         var thread = await channel.CreateThreadAsync(title, Discord.ThreadType.PublicThread, Discord.ThreadArchiveDuration.OneDay, messageParam);
                         if (AutoThreadChannel.CanArchive)
                         {
-                            var message = await thread.SendMessageAsync($"{messageParam.Author.Mention} this is your thread. You can do `!close` to archive it when you're done!");
+                            var message = await thread.SendMessageAsync(AutoThreadChannel.GenerateFirstMessage(messageParam.Author));
                             await message.PinAsync();
                         }
                     }

--- a/DiscordBot/Services/UserService.cs
+++ b/DiscordBot/Services/UserService.cs
@@ -503,7 +503,7 @@ namespace DiscordBot.Services
                     return;
                 // We add to dictionary with the time it must be passed before they'll be notified again.
                 _everyoneScoldCooldown[messageParam.Author.Id] = DateTime.Now.AddSeconds(_settings.EveryoneScoldPeriodSeconds);
-                
+
                 await messageParam.Channel.SendMessageAsync(
                         $"Please don't try to alert **everyone** on the server {messageParam.Author.Mention}!\nIf you are asking a question, people will help you when they have time.").DeleteAfterTime(minutes: 2);
             }
@@ -627,12 +627,11 @@ namespace DiscordBot.Services
                 {
                     try
                     {
-                        // var user = await this._client.GetUserAsync(messageParam.Author.Id);
                         var author = channel.Guild.GetUser(messageParam.Author.Id);
                         var authorName = author.Nickname;
                         if (String.IsNullOrEmpty(authorName)) authorName = author.Username;
                         var title = $"{AutoThreadChannel.Title} - {authorName}";
-                        var thread = await channel.CreateThreadAsync(title, Discord.ThreadType.PublicThread, Discord.ThreadArchiveDuration.OneDay, messageParam);
+                        await channel.CreateThreadAsync(title, Discord.ThreadType.PublicThread, Discord.ThreadArchiveDuration.OneDay, messageParam);
                     }
                     catch (Exception err)
                     {

--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -65,6 +65,8 @@ namespace DiscordBot.Settings.Deserialized
         public List<string> UserModuleSlapChoices { get; set; } = new List<string>(){"trout", "duck", "truck", "paddle", "magikarp", "sausage", "student loan", "low poly donut"};
         // How long between when the bot will scold a user for trying to ping everyone. Default 6 hours
         public ulong EveryoneScoldPeriodSeconds { get; set; } = 21600;
+        public List<AutoThreadChannel> AutoThreadChannels { get; set; } = new List<AutoThreadChannel>();
+        public List<string> AutoThreadExclusionPrefixes { get; set; } = new List<string>();
     }
 
     #region Role Group Collections
@@ -88,6 +90,12 @@ namespace DiscordBot.Settings.Deserialized
     public class ChannelInfo
     {
         public string Desc { get; set; }
+        public ulong Id { get; set; }
+    }
+
+    public class AutoThreadChannel
+    {
+        public string Title { get; set; }
         public ulong Id { get; set; }
     }
 

--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using Discord;
 
 namespace DiscordBot.Settings.Deserialized
 {
@@ -97,6 +99,23 @@ namespace DiscordBot.Settings.Deserialized
     {
         public string Title { get; set; }
         public ulong Id { get; set; }
+        public bool CanArchive { get; set; } = false;
+        public string TitleArchived { get; set; }
+
+        private string AuthorName(IUser author)
+        {
+            return ((IGuildUser)author).Nickname ?? author.Username;
+        }
+
+        public string GenerateTitle(IUser author)
+        {
+            return String.Format(this.Title, this.AuthorName(author));
+        }
+
+        public string GenerateTitleArchived(IUser author)
+        {
+            return String.Format(this.TitleArchived, this.AuthorName(author));
+        }
     }
 
     public class GeneralChannel : ChannelInfo

--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -102,19 +102,19 @@ namespace DiscordBot.Settings.Deserialized
         public bool CanArchive { get; set; } = false;
         public string TitleArchived { get; set; }
 
-        private string AuthorName(IUser author)
+        private static string AuthorName(IUser author)
         {
             return ((IGuildUser)author).Nickname ?? author.Username;
         }
 
         public string GenerateTitle(IUser author)
         {
-            return String.Format(this.Title, this.AuthorName(author));
+            return String.Format(this.Title, AuthorName(author));
         }
 
         public string GenerateTitleArchived(IUser author)
         {
-            return String.Format(this.TitleArchived, this.AuthorName(author));
+            return String.Format(this.TitleArchived, AuthorName(author));
         }
     }
 

--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -102,6 +102,8 @@ namespace DiscordBot.Settings.Deserialized
         public bool CanArchive { get; set; } = false;
         public string TitleArchived { get; set; }
 
+        public string FirstMessage { get; set; }
+
         private static string AuthorName(IUser author)
         {
             return ((IGuildUser)author).Nickname ?? author.Username;
@@ -115,6 +117,11 @@ namespace DiscordBot.Settings.Deserialized
         public string GenerateTitleArchived(IUser author)
         {
             return String.Format(this.TitleArchived, AuthorName(author));
+        }
+
+        public string GenerateFirstMessage(IUser author)
+        {
+            return String.Format(this.FirstMessage, author.Mention);
         }
     }
 


### PR DESCRIPTION
Fix #117

- Bot auto create threads after message in certain channels.
  - List of channels are configurable in config.
  - Thread name will be `[Title] - [UserName]` where `[Title]` is from the config.
- It will ignore messages written by bots
- It will ignore messages that start with some prefixes (like `!` or `w!`). In config.