### PR TITLE
Set reasonable docker-compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3.3"
 services:
   db:
     image: mysql


### PR DESCRIPTION
Docker-compose was throwing an exception on my system without the version specification.
`darkzek@zek-workstation:~/Projects/UDC-Bot$ docker-compose up ERROR: The Compose file './docker-compose.yml' is invalid because: Unsupported config option for services: 'bot' Unsupported config option for volumes: 'db_data'`