### PR TITLE
Return birthday to using a plain date string

### DIFF
--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -1039,7 +1039,7 @@ namespace DiscordBot.Modules
             {
                 var date = birthdate.ToUnixTimestamp();
                 var message =
-                    $"**{searchName}**'s birthdate: **<t:{date}:D>** " +
+                    $"**{searchName}**'s birthdate: __**{birthdate.ToString("dd MMMM yyyy", CultureInfo.InvariantCulture)}**__ " +
                     $"({(int)((DateTime.Now - birthdate).TotalDays / 365)}yo)";
 
                 await ReplyAsync(message).DeleteAfterTime(minutes: 3);


### PR DESCRIPTION
Returns date/days without the UTC since that is confusing people. 
It is a shame timestamp doesn't have similar tag just for days until date.