### PR TITLE
Feature/improved welcome

### DIFF
--- a/DiscordBot/Modules/ModerationModule.cs
+++ b/DiscordBot/Modules/ModerationModule.cs
@@ -10,6 +10,7 @@ using DiscordBot.Extensions;
 using DiscordBot.Services;
 using DiscordBot.Services.Logging;
 using DiscordBot.Settings.Deserialized;
+using DiscordBot.Utils.Attributes;
 using Pathoschild.NaturalTimeParser.Parser;
 
 namespace DiscordBot.Modules
@@ -442,6 +443,29 @@ namespace DiscordBot.Modules
             await _database.FullDbSync(Context.Guild, tracker);
         }
 
+        #region General Utility Commands
+        [Command("WelcomeMessageCount")]
+        [Summary("Returns a count of pending welcome messages.")]
+        [RequireModerator, HideFromHelp]
+        // Simple method to check if there are many welcome messages waiting, and when the next one is due.
+        public async Task WelcomeMessageCount()
+        {
+            var count = _user.WaitingWelcomeMessagesCount;
+            // If there are more than 0 messages waiting, show when nearest one is
+            if (count > 0)
+            {
+                var next = _user.NextWelcomeMessage.ToUnixTimestamp();
+                await ReplyAsync($"There are {count} pending welcome messages. The next one is in <t:{next}:R>").DeleteAfterSeconds(seconds: 10);
+            }
+            else
+            {
+                await ReplyAsync("There are no pending welcome messages.").DeleteAfterSeconds(seconds: 10);
+            }
+            await Context.Message.DeleteAsync();
+        }
+
+        #endregion
+        
         #region CommandList
         [RequireModerator]
         [Summary("Does what you see now.")]

--- a/DiscordBot/Modules/ModerationModule.cs
+++ b/DiscordBot/Modules/ModerationModule.cs
@@ -450,11 +450,11 @@ namespace DiscordBot.Modules
         // Simple method to check if there are many welcome messages waiting, and when the next one is due.
         public async Task WelcomeMessageCount()
         {
-            var count = _user.WaitingWelcomeMessagesCount;
+            var count = UserService.WaitingWelcomeMessagesCount;
             // If there are more than 0 messages waiting, show when nearest one is
             if (count > 0)
             {
-                var next = _user.NextWelcomeMessage.ToUnixTimestamp();
+                var next = UserService.NextWelcomeMessage.ToUnixTimestamp();
                 await ReplyAsync($"There are {count} pending welcome messages. The next one is in <t:{next}:R>").DeleteAfterSeconds(seconds: 10);
             }
             else

--- a/DiscordBot/Services/UserService.cs
+++ b/DiscordBot/Services/UserService.cs
@@ -53,6 +53,8 @@ namespace DiscordBot.Services
         private readonly Random _rand;
 
         public Dictionary<ulong, DateTime> MutedUsers { get; private set; }
+        public int WaitingWelcomeMessagesCount => _welcomeNoticeUsers.Count;
+        public DateTime NextWelcomeMessage => _welcomeNoticeUsers.Any() ? _welcomeNoticeUsers.Min(x => x.time) : DateTime.MaxValue;
 
         public UserService(DiscordSocketClient client, DatabaseService databaseService, ILoggingService loggingService, UpdateService updateService,
                            Settings.Deserialized.Settings settings, UserSettings userSettings)
@@ -125,7 +127,8 @@ namespace DiscordBot.Services
             _client.UserJoined += UserJoined;
             _client.GuildMemberUpdated += UserUpdated;
             _client.UserLeft += UserLeft;
-            _client.MessageReceived += EarlyWelcome;
+
+            _client.UserIsTyping += UserIsTyping;
 
             LoadData();
             UpdateLoop();
@@ -519,27 +522,15 @@ namespace DiscordBot.Services
         // Anything relevant to the first time someone connects to the server
         #region Welcome Service
         // If a user talks before they've been welcomed, we welcome them and remove them from the welcome list so they're not welcomes a second time.
-        public async Task EarlyWelcome(SocketMessage messageParam)
+        private async Task UserIsTyping(Cacheable<IUser, ulong> user, Cacheable<IMessageChannel, ulong> channel)
         {
             if (_welcomeNoticeUsers.Count == 0)
                 return;
-            if (messageParam.Author.IsBot)
+            if (user.Value.IsBot)
                 return;
-            if (messageParam.Content == string.Empty)
-                return;
-            
-            if (_welcomeNoticeUsers.Exists(u => u.id == messageParam.Author.Id))
-            {
-                var offTopic = await _client.GetChannelAsync(_settings.GeneralChannel.Id) as SocketTextChannel;
-                var em = WelcomeMessage(messageParam.Author as SocketGuildUser);
-                if (offTopic != null)
-                    await offTopic.SendMessageAsync(string.Empty, false, em);
-                
-                // Remove the user from the welcome list.
-                _welcomeNoticeUsers.RemoveAll(u => u.id == messageParam.Author.Id);
-            }
-        }
 
+            await ProcessWelcomeUser(user.Id, user.Value);
+        }
         private async Task UserJoined(SocketGuildUser user)
         {
             // Send them the Welcome DM first.
@@ -579,22 +570,14 @@ namespace DiscordBot.Services
         {
             try
             {
-                var guild = _client.GetGuild(_settings.GuildId);
-                var offTopic = guild.GetChannel(_settings.GeneralChannel.Id) as SocketTextChannel;
-                
                 while (true)
                 {
                     var now = DateTime.Now;
-                    while (_welcomeNoticeUsers.Count > 0 && now > _welcomeNoticeUsers[0].time)
+                    // This could be optimized, however the users in this list won't ever really be large enough to matter.
+                    // We loop through our list, anyone that has been in the list for more than x seconds is welcomed.
+                    foreach (var userData in _welcomeNoticeUsers.Where(u => u.time < now))
                     {
-                        var user = guild.GetUser(_welcomeNoticeUsers[0].id);
-                        if (user != null)
-                        {
-                            var em = WelcomeMessage(user);
-                            if (offTopic != null)
-                                await offTopic.SendMessageAsync(string.Empty, false, em);
-                        }
-                        _welcomeNoticeUsers.RemoveAt(0);
+                        await ProcessWelcomeUser(userData.id, null);
                     }
                     await Task.Delay(10000);
                 }
@@ -606,7 +589,27 @@ namespace DiscordBot.Services
                 await _loggingService.LogAction($"UserServer Exception during welcome message.\n{e.Message}.", false, true);
             }
         }
-        
+
+        private async Task ProcessWelcomeUser(ulong userID, IUser user = null)
+        {
+            if (_welcomeNoticeUsers.Exists(u => u.id == userID))
+            {
+                // If we didn't get the user passed in, we try grab it
+                user ??= await _client.GetUserAsync(userID);
+                // if they're null, they've likely left, so we just remove them from the list.
+                if (user != null)
+                {
+                    var offTopic = await _client.GetChannelAsync(_settings.GeneralChannel.Id) as SocketTextChannel;
+                    var em = WelcomeMessage(user as SocketGuildUser);
+                    if (offTopic != null)
+                        await offTopic.SendMessageAsync(string.Empty, false, em);
+                }
+                // Remove the user from the welcome list.
+                _welcomeNoticeUsers.RemoveAll(u => u.id == userID);
+            }
+        }
+
+
         public async Task<bool> DMFormattedWelcome(SocketGuildUser user)
         {
             var dm = await user.CreateDMChannelAsync();

--- a/DiscordBot/Services/UserService.cs
+++ b/DiscordBot/Services/UserService.cs
@@ -561,7 +561,7 @@ namespace DiscordBot.Services
             // We check if they're already in the welcome list, if they are we don't add them again to avoid double posts
             if (_welcomeNoticeUsers.Count == 0 || !_welcomeNoticeUsers.Exists(u => u.id == user.Id))
             {
-                _welcomeNoticeUsers.Add((user.Id, DateTime.Now.AddSeconds(_settings.WelcomeMessageDelaySeconds * 1000)));
+                _welcomeNoticeUsers.Add((user.Id, DateTime.Now.AddSeconds(_settings.WelcomeMessageDelaySeconds)));
             }
         }
         


### PR DESCRIPTION
Improves how welcome messages are shown.

When a user connects they're given a delay so they're not welcomed before they've had a chance to look around, and/or if they've been limited by discord and can't talk for x number of minutes.

if they user starts typing before they've been welcomed, the bot will attempt to immediately welcome them before they've sent the message. This is in an attempt to avoid less confusion from users.

Commands:
- WelcomeMessageCount : just shows how many people haven't been welcomed yet, and when the next one is due. Fairly useless, but gives a bit of debug information should I need it.

Bug Fixes:
- Also fixed that users wern't being welcomed for over 3 days due to a bug from earlier changes, this was mostly missed as anyone who talked would be welcomed.