### PR TITLE
Fix/bot reliability

### DIFF
--- a/DiscordBot/Modules/ReminderModule.cs
+++ b/DiscordBot/Modules/ReminderModule.cs
@@ -164,13 +164,13 @@ public class ReminderModule : ModuleBase
     [Summary("Used to restart the reminder service if it has crashed.")]
     public async Task RebootReminderService()
     {
-        if (ReminderService.IsRunning())
+        if (ReminderService.IsRunning)
         {
             await ReplyAsync("Reminder service is still running.").DeleteAfterSeconds(seconds: 5);
             return;
         }
 
-        var result = await ReminderService.RestartService();
+        var result = ReminderService.RestartService();
         if (result)
             await ReplyAsync("Reminder service restarted.").DeleteAfterSeconds(seconds: 5);
         else

--- a/DiscordBot/Services/ReactRoleService.cs
+++ b/DiscordBot/Services/ReactRoleService.cs
@@ -35,9 +35,8 @@ public class ReactRoleService
         _client = client;
         _client.ReactionAdded += ReactionAdded;
         _client.ReactionRemoved += ReactionRemoved;
-
-        // Event so we can Initialize
-        _client.Ready += ClientIsReady;
+        
+        Task.Run(async () => _isRunning = await StartService());
     }
 
     // These are for the Modules to reference if/when setting up new message roles.
@@ -138,11 +137,6 @@ public class ReactRoleService
 
         _isRunning = true;
         return true;
-    }
-
-    private async Task ClientIsReady()
-    {
-        _isRunning = await StartService();
     }
 
     private async Task ReactionAdded(Cacheable<IUserMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel, SocketReaction reaction)

--- a/DiscordBot/Services/UserService.cs
+++ b/DiscordBot/Services/UserService.cs
@@ -148,12 +148,8 @@ public class UserService
 
         LoadData();
         UpdateLoop();
-
-        _client.Ready += () =>
-        {
-            Task.Run(DelayedWelcomeService);
-            return Task.CompletedTask;
-        };
+        
+        Task.Run(DelayedWelcomeService);
     }
 
     public Dictionary<ulong, DateTime> CodeReminderCooldown { get; private set; }
@@ -643,9 +639,9 @@ public class UserService
         catch (Exception e)
         {
             // Catch and show exception
-            LoggingService.LogToConsole($"UserServer Exception during welcome message.\n{e.Message}",
+            LoggingService.LogToConsole($"UserService Exception during welcome message.\n{e.Message}",
                 LogSeverity.Error);
-            await _loggingService.LogAction($"UserServer Exception during welcome message.\n{e.Message}.", false, true);
+            await _loggingService.LogAction($"UserService Exception during welcome message.\n{e.Message}.", false, true);
         }
     }
 


### PR DESCRIPTION
Should fix situations where the client (bot) can't communicate with discord servers for a few minutes and then reconnects.

I'm unsure if interactions will remain setup after such a disconnect since they need manual setup, but that should be an easy fix should it become the case. Until then, at least chat commands won't fire twice.

I also fixed client.Ready events in other services, I believe I removed these a while ago, I/we must have goof'ed a merge somewhere. Since services won't be setup until after client is ready now, the event itself is redudant and unusued which caused problems for services that had an update loop.