### PR TITLE
Feature - ContextMenu Report message

### DIFF
--- a/DiscordBot/Modules/UserSlashModule.cs
+++ b/DiscordBot/Modules/UserSlashModule.cs
@@ -142,8 +142,8 @@ public class UserSlashModule : InteractionModuleBase
             return;
         }
 
-        var botAnnouncementChannel = await Context.Guild.GetTextChannelAsync(BotSettings.BotAnnouncementChannel.Id);
-        if (botAnnouncementChannel == null)
+        var reportedMessageChannel = await Context.Guild.GetTextChannelAsync(BotSettings.ReportedMessageChannel.Id);
+        if (reportedMessageChannel == null)
             return;
 
         var embed = new EmbedBuilder();
@@ -167,7 +167,7 @@ public class UserSlashModule : InteractionModuleBase
             }
             embed.AddField("Attachments", attachmentString);
         }
-        await botAnnouncementChannel.SendMessageAsync(string.Empty, embed: embed.Build());
+        await reportedMessageChannel.SendMessageAsync(string.Empty, embed: embed.Build());
         
         await Context.Interaction.ModifyOriginalResponseAsync(msg => msg.Content = $"Message has been reported.");
     }

--- a/DiscordBot/Modules/UserSlashModule.cs
+++ b/DiscordBot/Modules/UserSlashModule.cs
@@ -119,6 +119,32 @@ public class UserSlashModule : InteractionModuleBase
         await Context.Interaction.RespondAsync(text: BotSettings.Invite, ephemeral: true);
     }
 
+    #region Moderation
+
+    [MessageCommand("Report Message")]
+    public async Task ReportMessage(IMessage reportedMessage)
+    {
+        await Context.Interaction.DeferAsync(ephemeral: true);
+        
+        var botAnnouncementChannel = await Context.Guild.GetTextChannelAsync(BotSettings.BotAnnouncementChannel.Id);
+        if (botAnnouncementChannel == null)
+            return;
+
+        var embed = new EmbedBuilder();
+        embed.WithTitle($"Message Reported");
+        embed.WithDescription($"{Context.User.Username}#{Context.User.Discriminator} reported a message in #{Context.Channel.Name}. [GoTo]({reportedMessage.GetJumpUrl()})");
+        embed.WithColor(new Color(0xFF0000));
+        embed.AddField("Reported Content",
+            $"User: {reportedMessage.Author.Username}#{reportedMessage.Author.Discriminator} - {reportedMessage.Author.Id}\n" +
+            $"Content:\n{(reportedMessage.Content.Length > 200 ? reportedMessage.Content.Substring(0, 200) + "..." : reportedMessage.Content)}");
+        
+        await botAnnouncementChannel.SendMessageAsync(string.Empty, embed: embed.Build());
+        
+        await Context.Interaction.ModifyOriginalResponseAsync(msg => msg.Content = $"Message has been reported.");
+    }
+
+    #endregion // Moderation
+    
     #region User Roles
     
     [SlashCommand("roles", "Give or Remove roles for yourself (Programmer, Artist, Designer, etc)")]

--- a/DiscordBot/Modules/UserSlashModule.cs
+++ b/DiscordBot/Modules/UserSlashModule.cs
@@ -126,6 +126,22 @@ public class UserSlashModule : InteractionModuleBase
     {
         await Context.Interaction.DeferAsync(ephemeral: true);
         
+        if (reportedMessage.Author.Id == Context.User.Id)
+        {
+            await Context.Interaction.FollowupAsync(text: "You can't report your own messages!", ephemeral: true);
+            return;
+        }
+        if (reportedMessage.Author.IsBot) // Don't report bots
+        {
+            await Context.Interaction.FollowupAsync(text: "You can't report bot messages!", ephemeral: true);
+            return;
+        }
+        if (reportedMessage.Author.IsWebhook) // Don't report webhooks
+        {
+            await Context.Interaction.FollowupAsync(text: "You can't report webhook messages!", ephemeral: true);
+            return;
+        }
+
         var botAnnouncementChannel = await Context.Guild.GetTextChannelAsync(BotSettings.BotAnnouncementChannel.Id);
         if (botAnnouncementChannel == null)
             return;

--- a/DiscordBot/Modules/UserSlashModule.cs
+++ b/DiscordBot/Modules/UserSlashModule.cs
@@ -154,6 +154,19 @@ public class UserSlashModule : InteractionModuleBase
             $"User: {reportedMessage.Author.Username}#{reportedMessage.Author.Discriminator} - {reportedMessage.Author.Id}\n" +
             $"Content:\n{(reportedMessage.Content.Length > 200 ? reportedMessage.Content.Substring(0, 200) + "..." : reportedMessage.Content)}");
         
+        // Links to any attachments included in the message so even if deleted, we can still see content
+        if (reportedMessage.Attachments.Count > 0)
+        {
+            var attachments = reportedMessage.Attachments.Select(a => a.Url).ToList();
+            string attachmentString = string.Empty;
+            for (int i = 0; i < attachments.Count; i++)
+            {
+                attachmentString += $"[{i + 1}]({attachments[i]})";
+                if (i < attachments.Count - 1)
+                    attachmentString += "\n";
+            }
+            embed.AddField("Attachments", attachmentString);
+        }
         await botAnnouncementChannel.SendMessageAsync(string.Empty, embed: embed.Build());
         
         await Context.Interaction.ModifyOriginalResponseAsync(msg => msg.Content = $"Message has been reported.");

--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -56,6 +56,8 @@ public class BotSettings
     public WorkForHireChannel LookingForWork { get; set; }
     public CollaborationChannel CollaborationChannel { get; set; }
     
+    public ChannelInfo ReportedMessageChannel { get; set; }
+    
     #region Complaint Channel
 
     public ulong ComplaintCategoryId { get; set; }

--- a/DiscordBot/Settings/Settings.example.json
+++ b/DiscordBot/Settings/Settings.example.json
@@ -68,6 +68,10 @@
     "desc": "Collaboration Channel",
     "id": "0" // Currently Unused 29/04/21
   },
+  "ReportedMessageChannel": {
+    "desc": "Reported Message Channel",
+    "id": "0"
+  },
   /* Role Ids */
   "mutedRoleID": "0",
   "publisherRoleID": "0",


### PR DESCRIPTION
Users can now right click on a message or click the `...` which will have a "Report Message" button, the reported message content/author/attachments are posted into bot-commands.

Note: 
Obviously posting this in bot-commands isn't appropriate as it'll be lost to spam, do we want a new channel? or post it into one of the other moderator channels? If so, which?

Behaviour:
- Can't report self, bot or webhooks

![image](https://user-images.githubusercontent.com/8342701/177106233-93d89842-e4bb-4096-9734-bec4d1cf6e9b.png)

![image](https://user-images.githubusercontent.com/8342701/177106366-6173e348-7d3c-402b-83c8-29d55f9efc88.png)

A context message is also sent as response to confirm the message was reported.
