### PR TITLE
[Improvement] Multi-User reminders

### DIFF
--- a/DiscordBot/Modules/ReminderModule.cs
+++ b/DiscordBot/Modules/ReminderModule.cs
@@ -73,7 +73,7 @@ public class ReminderModule : ModuleBase
         };
 
         ReminderService.AddReminder(reminder);
-        await Context.Message.AddReactionAsync(new Emoji("✅"));
+        await Context.Message.AddReactionAsync(ReminderService.BotResponseEmoji);
         await ReplyAsync(
                 $"Reminder set for {Utils.Utils.FormatTime((uint)(reminderDate - DateTime.Now).TotalSeconds)}")
             .DeleteAfterSeconds(seconds: 10);

--- a/DiscordBot/Services/ReminderService.cs
+++ b/DiscordBot/Services/ReminderService.cs
@@ -14,6 +14,9 @@ public class ReminderItem {
 
 public class ReminderService
 {
+    // Bot responds to reminder request, any users who also use this emoji on the message will be pinged when the reminder is triggered.
+    public static readonly Emoji BotResponseEmoji = new Emoji("✅");
+    
     public bool IsRunning { get; private set; }
     
     private DateTime _nearestReminder = DateTime.Now;

--- a/DiscordBot/Services/ReminderService.cs
+++ b/DiscordBot/Services/ReminderService.cs
@@ -137,8 +137,24 @@ public class ReminderService
                     // We reply to their original message
                     if (message != null)
                     {
-                        await message.ReplyAsync(
-                            $"{message.Author.Mention} reminder: {reminder.Message}");
+                        string botResponse = $"{message.Author.Mention} reminder: \"{reminder.Message}\"";
+                        // Get the people who reacted to the message 
+                        var includeUsers = await message.GetReactionUsersAsync(BotResponseEmoji, 10).FlattenAsync();
+                        string extraUsers = string.Empty;
+                        foreach (IUser includeUser in includeUsers)
+                        {
+                            if (includeUser.IsBot)
+                                continue;
+                            if (includeUser.Id == message.Author.Id)
+                                continue;
+
+                            extraUsers += $"{includeUser.Mention} ";
+                        }
+                        // If there are any extra users, we add them to the bot response
+                        if (extraUsers != string.Empty)
+                            botResponse += $"\n\nReacted Extras: {extraUsers}";
+                        
+                        await message.ReplyAsync(botResponse);
                         continue;
                     }
                     // If channel is null we get the bot command channel, and send the message there
@@ -146,7 +162,7 @@ public class ReminderService
                     var user = _client.GetUser(reminder.UserId);
                     if (user != null)
                         await channel.SendMessageAsync(
-                            $"{user.Mention} reminder: {reminder.Message}");
+                            $"{user.Mention} reminder: \"{reminder.Message}\"");
                 }
 
                 // Find the nearest reminder in _reminders and set if there is at least 1 reminder


### PR DESCRIPTION
Once a user uses `!remindme 5months whatever` the bot uses a configured emote to indicate that it is live. If other users use the same reaction, they will be pinged in the message when the reminder triggers.

This might be useful for people who want to organize an event together, or be reminded of a certain thing. The piggy-back reminder does not consume one of the users reminders as the reaction is checked when the reminder is due. If a user removes their reaction, they will no longer be reminded once the reminder is fired.

A max limit of 10 users will be reminded (+1 for author)

This will also work retrospectively, but messages without the reaction won't get the additional pings. (The emote was only added the other week/month?)