### PR TITLE
Fix incorrect object comparison

### DIFF
--- a/DiscordBot/Modules/WeatherModule.cs
+++ b/DiscordBot/Modules/WeatherModule.cs
@@ -297,7 +297,7 @@ public class WeatherModule : ModuleBase
 
     private async Task<bool> IsResultsValid<T>(T res)
     {
-        if (object.Equals(res, default(T))) return true;
+        if (!object.Equals(res, default(T))) return true;
 
         await ReplyAsync("API Returned no results.");
         return false;


### PR DESCRIPTION
Hi there!

I'm Pawan Kartik and I work at DeepSource. Our internal logs indicated that the Autofix generated for this particular line in the pull request https://github.com/Unity-Developer-Community/UDC-Bot/pull/217 might not be accurate.

Actual line from the source:
```csharp
if (res != null) return true;
```

Autofix generated:
```csharp
if (object.Equals(res, default(T))) return true;
```

Ideal code that should've been generated:
```csharp
if (!object.Equals(res, default(T))) return true;
```

This PR fixes the incorrect code that was generated. Additionally, we've staged a fix internally that should roll out globally in a couple of hours.

We sincerely regret the inconvenience caused.