### PR TITLE
Feature - Forum Improvements & Help Service

### DIFF
--- a/DiscordBot/DiscordBot.csproj
+++ b/DiscordBot/DiscordBot.csproj
@@ -5,7 +5,7 @@
     <LangVersion>10</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="3.8.1" />
+    <PackageReference Include="Discord.Net" Version="3.9.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="Insight.Database" Version="6.3.10" />
     <PackageReference Include="Magick.NET-Q8-x64" Version="7.5.0.1" />

--- a/DiscordBot/Extensions/ChannelExtensions.cs
+++ b/DiscordBot/Extensions/ChannelExtensions.cs
@@ -1,0 +1,22 @@
+using Discord.WebSocket;
+
+namespace DiscordBot.Extensions;
+
+public static class ChannelExtensions
+{
+    public static bool IsThreadInForumChannel(this IMessageChannel channel)
+    {
+        if (channel is not SocketThreadChannel threadChannel)
+            return false;
+        if (threadChannel.ParentChannel is not SocketForumChannel parentChannel)
+            return false;
+        return true;
+    }
+    
+    public static bool IsThreadInChannel(this IMessageChannel channel, ulong channelId)
+    {
+        if (!channel.IsThreadInForumChannel())
+            return false;
+        return ((SocketThreadChannel)channel).ParentChannel.Id == channelId;
+    }
+}

--- a/DiscordBot/Extensions/StringExtensions.cs
+++ b/DiscordBot/Extensions/StringExtensions.cs
@@ -119,9 +119,12 @@ public static class StringExtensions
         return sb.ToString();
     }
     
+    /// <summary>
+    /// Returns true if the string contains only upper case characters, including spaces and all punctuation ie; "I NEED HELP!?!?!?!#$?!" will return true 
+    /// </summary>
     public static bool IsAlLCaps(this string str)
     {
-        return str.All(char.IsUpper);
+        return Regex.IsMatch(str, @"^[A-Z\s\p{P}]+$");
     }
     
     public static string ToCapitalizeFirstLetter(this string str)

--- a/DiscordBot/Extensions/StringExtensions.cs
+++ b/DiscordBot/Extensions/StringExtensions.cs
@@ -118,4 +118,16 @@ public static class StringExtensions
         // Return the hexadecimal string.
         return sb.ToString();
     }
+    
+    public static bool IsAlLCaps(this string str)
+    {
+        return str.All(char.IsUpper);
+    }
+    
+    public static string ToCapitalizeFirstLetter(this string str)
+    {
+        if (string.IsNullOrEmpty(str))
+            return string.Empty;
+        return char.ToUpper(str[0]) + str[1..];
+    }
 }

--- a/DiscordBot/Extensions/UserExtensions.cs
+++ b/DiscordBot/Extensions/UserExtensions.cs
@@ -1,3 +1,5 @@
+using Discord.WebSocket;
+
 namespace DiscordBot.Extensions;
 
 public static class UserExtensions
@@ -5,5 +7,14 @@ public static class UserExtensions
     public static bool IsUserBotOrWebhook(this IUser user)
     {
         return user.IsBot || user.IsWebhook;
+    }
+    
+    public static bool HasRoleGroup(this IUser user, SocketRole role) 
+    {
+        return HasRoleGroup(user, role.Id);
+    }
+    public static bool HasRoleGroup(this IUser user, ulong roleId)
+    {
+        return user is SocketGuildUser guildUser && guildUser.Roles.Any(x => x.Id == roleId);
     }
 }

--- a/DiscordBot/Extensions/UserExtensions.cs
+++ b/DiscordBot/Extensions/UserExtensions.cs
@@ -1,0 +1,9 @@
+namespace DiscordBot.Extensions;
+
+public static class UserExtensions
+{
+    public static bool IsUserBotOrWebhook(this IUser user)
+    {
+        return user.IsBot || user.IsWebhook;
+    }
+}

--- a/DiscordBot/Modules/UnityHelp/UnityHelpInteractiveModule.cs
+++ b/DiscordBot/Modules/UnityHelp/UnityHelpInteractiveModule.cs
@@ -10,9 +10,8 @@ public class UnityHelpInteractiveModule : InteractionModuleBase
     #region Dependency Injection
 
     public UnityHelpService HelpService { get; set; }
-    public UserService UserService { get; set; }
     public BotSettings BotSettings { get; set; }
-
+    
     #endregion // Dependency Injection
 
     [SlashCommand("resolve-question", "If in unity-help forum channel, resolve the thread")]
@@ -35,15 +34,12 @@ public class UnityHelpInteractiveModule : InteractionModuleBase
 
         var response =
             await HelpService.OnUserRequestChannelClose(Context.User, Context.Channel as SocketThreadChannel);
-        if (string.IsNullOrEmpty(response))
-            await Context.Interaction.FollowupAsync(string.Empty, ephemeral: true);
-        else
-            await Context.Interaction.FollowupAsync(response, ephemeral: true);
+        await Context.Interaction.FollowupAsync(response, ephemeral: true);
     }
 
-    #region Context Commands
+    #region Message Commands
 
-    [MessageCommand("Mark as Correct Answer")]
+    [MessageCommand("Correct Answer")]
     public async Task MarkResponseAnswer(IMessage targetResponse)
     {
         await Context.Interaction.DeferAsync(ephemeral: true);
@@ -64,34 +60,18 @@ public class UnityHelpInteractiveModule : InteractionModuleBase
             await Context.Interaction.FollowupAsync("You can't mark your own response as correct", ephemeral: true);
             return;
         }
-        
+
         var response = await HelpService.MarkResponseAsAnswer(Context.User, targetResponse);
-        if (string.IsNullOrEmpty(response))
-            await Context.Interaction.FollowupAsync(string.Empty, ephemeral: true);
-        else
-            await Context.Interaction.FollowupAsync(response, ephemeral: true);
+        await Context.Interaction.FollowupAsync( response, ephemeral: true);
     }
 
     #endregion // Context Commands
     
 
     #region Utility
-
-    bool IsInHelpChannel()
-    {
-        if (Context.Channel is SocketThreadChannel threadChannel)
-        {
-            return threadChannel.ParentChannel.Id == BotSettings.GenericHelpChannel.Id;
-        }
-        return false;
-    }
     
-    bool IsValidUser()
-    {
-        if (Context.User.IsBot || Context.User.IsWebhook)
-            return false;
-        return true;
-    }
+    private bool IsInHelpChannel() => Context.Channel.IsThreadInChannel(BotSettings.GenericHelpChannel.Id);
+    private bool IsValidUser() => !Context.User.IsUserBotOrWebhook();
 
     #endregion // Utility
 }

--- a/DiscordBot/Modules/UnityHelp/UnityHelpInteractiveModule.cs
+++ b/DiscordBot/Modules/UnityHelp/UnityHelpInteractiveModule.cs
@@ -1,0 +1,97 @@
+using Discord.Interactions;
+using DiscordBot.Services;
+using DiscordBot.Settings;
+using Discord.WebSocket;
+
+namespace DiscordBot.Modules;
+
+public class UnityHelpInteractiveModule : InteractionModuleBase
+{
+    #region Dependency Injection
+
+    public UnityHelpService HelpService { get; set; }
+    public UserService UserService { get; set; }
+    public BotSettings BotSettings { get; set; }
+
+    #endregion // Dependency Injection
+
+    [SlashCommand("resolve-question", "If in unity-help forum channel, resolve the thread")]
+    public async Task ResolveQuestion()
+    {
+        await Context.Interaction.DeferAsync(ephemeral: true);
+
+        if (!IsValidUser())
+        {
+            await Context.Interaction.RespondAsync("Invalid User", ephemeral: true);
+            return;
+        }
+
+        if (!IsInHelpChannel())
+        {
+            await Context.Interaction.FollowupAsync(
+                $"This command can only be used in <#{BotSettings.GenericHelpChannel.Id}> channels", ephemeral: true);
+            return;
+        }
+
+        var response =
+            await HelpService.OnUserRequestChannelClose(Context.User, Context.Channel as SocketThreadChannel);
+        if (string.IsNullOrEmpty(response))
+            await Context.Interaction.FollowupAsync(string.Empty, ephemeral: true);
+        else
+            await Context.Interaction.FollowupAsync(response, ephemeral: true);
+    }
+
+    #region Context Commands
+
+    [MessageCommand("Mark as Correct Answer")]
+    public async Task MarkResponseAnswer(IMessage targetResponse)
+    {
+        await Context.Interaction.DeferAsync(ephemeral: true);
+        if (!IsValidUser())
+        {
+            await Context.Interaction.RespondAsync(string.Empty, ephemeral: true);
+            return;
+        }
+        if (!IsInHelpChannel())
+        {
+            await Context.Interaction.FollowupAsync(
+                $"This command can only be used in <#{BotSettings.GenericHelpChannel.Id}> channels", ephemeral: true);
+            return;
+        }
+
+        if (targetResponse.Author == Context.User || targetResponse.Author.IsBot)
+        {
+            await Context.Interaction.FollowupAsync("You can't mark your own response as correct", ephemeral: true);
+            return;
+        }
+        
+        var response = await HelpService.MarkResponseAsAnswer(Context.User, targetResponse);
+        if (string.IsNullOrEmpty(response))
+            await Context.Interaction.FollowupAsync(string.Empty, ephemeral: true);
+        else
+            await Context.Interaction.FollowupAsync(response, ephemeral: true);
+    }
+
+    #endregion // Context Commands
+    
+
+    #region Utility
+
+    bool IsInHelpChannel()
+    {
+        if (Context.Channel is SocketThreadChannel threadChannel)
+        {
+            return threadChannel.ParentChannel.Id == BotSettings.GenericHelpChannel.Id;
+        }
+        return false;
+    }
+    
+    bool IsValidUser()
+    {
+        if (Context.User.IsBot || Context.User.IsWebhook)
+            return false;
+        return true;
+    }
+
+    #endregion // Utility
+}

--- a/DiscordBot/Modules/UnityHelp/UnityHelpModule.cs
+++ b/DiscordBot/Modules/UnityHelp/UnityHelpModule.cs
@@ -17,32 +17,17 @@ public class UnityHelpModule : ModuleBase
 
     [Command("resolve"), Alias("complete")]
     [Summary("When a question is answered, use this command to mark it as resolved.")]
-    public async Task ResolveAsync() 
+    public async Task ResolveAsync()
     {
         if (!IsValidUser() || !IsInHelpChannel())
-        {
             await Context.Message.DeleteAsync();
-        }
         await HelpService.OnUserRequestChannelClose(Context.User, Context.Channel as SocketThreadChannel);
     }
-    
+
     #region Utility
 
-    bool IsInHelpChannel()
-    {
-        if (Context.Channel is SocketThreadChannel threadChannel)
-        {
-            return threadChannel.ParentChannel.Id == BotSettings.GenericHelpChannel.Id;
-        }
-        return false;
-    }
-    
-    bool IsValidUser()
-    {
-        if (Context.User.IsBot || Context.User.IsWebhook)
-            return false;
-        return true;
-    }
+    private bool IsInHelpChannel() => Context.Channel.IsThreadInChannel(BotSettings.GenericHelpChannel.Id);
+    private bool IsValidUser() => !Context.User.IsUserBotOrWebhook();
 
     #endregion // Utility
 }

--- a/DiscordBot/Modules/UnityHelp/UnityHelpModule.cs
+++ b/DiscordBot/Modules/UnityHelp/UnityHelpModule.cs
@@ -1,0 +1,48 @@
+using Discord.Commands;
+using Discord.WebSocket;
+using DiscordBot.Services;
+using DiscordBot.Settings;
+
+namespace DiscordBot.Modules;
+
+public class UnityHelpModule : ModuleBase
+{
+    #region Dependency Injection
+
+    public UnityHelpService HelpService { get; set; }
+    public UserService UserService { get; set; }
+    public BotSettings BotSettings { get; set; }
+
+    #endregion // Dependency Injection
+
+    [Command("resolve"), Alias("complete")]
+    [Summary("When a question is answered, use this command to mark it as resolved.")]
+    public async Task ResolveAsync() 
+    {
+        if (!IsValidUser() || !IsInHelpChannel())
+        {
+            await Context.Message.DeleteAsync();
+        }
+        await HelpService.OnUserRequestChannelClose(Context.User, Context.Channel as SocketThreadChannel);
+    }
+    
+    #region Utility
+
+    bool IsInHelpChannel()
+    {
+        if (Context.Channel is SocketThreadChannel threadChannel)
+        {
+            return threadChannel.ParentChannel.Id == BotSettings.GenericHelpChannel.Id;
+        }
+        return false;
+    }
+    
+    bool IsValidUser()
+    {
+        if (Context.User.IsBot || Context.User.IsWebhook)
+            return false;
+        return true;
+    }
+
+    #endregion // Utility
+}

--- a/DiscordBot/Program.cs
+++ b/DiscordBot/Program.cs
@@ -23,6 +23,8 @@ public class Program
     private InteractionService _interactionService;
     private IServiceProvider _services;
 
+    private UnityHelpService _unityHelpService;
+
     public static void Main(string[] args) =>
         new Program().MainAsync().GetAwaiter().GetResult();
 
@@ -64,6 +66,8 @@ public class Program
 
                 LoggingService.LogToConsole("Bot is connected.", LogSeverity.Info);
                 _isInitialized = true;
+                
+                _unityHelpService = _services.GetRequiredService<UnityHelpService>();
             }
             return Task.CompletedTask;
         };
@@ -86,6 +90,7 @@ public class Program
             .AddSingleton<ModerationService>()
             .AddSingleton<PublisherService>()
             .AddSingleton<FeedService>()
+            .AddSingleton<UnityHelpService>()
             .AddSingleton<UpdateService>()
             .AddSingleton<CurrencyService>()
             .AddSingleton<ReactRoleService>()

--- a/DiscordBot/Services/LoggingService.cs
+++ b/DiscordBot/Services/LoggingService.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Diagnostics;
+using System.IO;
 using Discord.WebSocket;
 using DiscordBot.Settings;
 
@@ -61,6 +62,17 @@ public class LoggingService : ILoggingService
 
         Console.ForegroundColor = restoreColour;
     }
+    
+    /// <summary>
+    /// Same behaviour as LogToConsole, however this method is not included in the release build.
+    /// Good if you need more verbose but obvious logging, but don't want it included in release.
+    /// </summary>
+    [Conditional("DEBUG")]
+    public static void DebugLog(string message, LogSeverity severity = LogSeverity.Info)
+    {
+        LogToConsole(message, severity);
+    }
+    
     private static void SetConsoleColour(LogSeverity severity)
     {
         switch (severity)

--- a/DiscordBot/Services/LoggingService.cs
+++ b/DiscordBot/Services/LoggingService.cs
@@ -25,18 +25,18 @@ public class LoggingService : ILoggingService
         }
 
         if (logToFile)
-            File.AppendAllText(_settings.ServerRootPath + @"/log.txt",
-                $"[{ConsistantDateTimeFormat()}] {action} {Environment.NewLine}");
+            await File.AppendAllTextAsync(_settings.ServerRootPath + @"/log.txt",
+                $"[{ConsistentDateTimeFormat()}] {action} {Environment.NewLine}");
     }
 
     public void LogXp(string channel, string user, float baseXp, float bonusXp, float xpReduce, int totalXp)
     {
         File.AppendAllText(_settings.ServerRootPath + @"/logXP.txt",
-            $"[{ConsistantDateTimeFormat()}] - {user} gained {totalXp}xp (base: {baseXp}, bonus : {bonusXp}, reduce : {xpReduce}) in channel {channel} {Environment.NewLine}");
+            $"[{ConsistentDateTimeFormat()}] - {user} gained {totalXp}xp (base: {baseXp}, bonus : {bonusXp}, reduce : {xpReduce}) in channel {channel} {Environment.NewLine}");
     }
 
     // Returns DateTime.Now in format: d/M/yy HH:mm:ss
-    public static string ConsistantDateTimeFormat()
+    public static string ConsistentDateTimeFormat()
     {
         return DateTime.Now.ToString("d/M/yy HH:mm:ss");
     }
@@ -50,14 +50,14 @@ public class LoggingService : ILoggingService
     #region Console Messages
     // Logs message to console without changing the colour
     public static void LogConsole(string message) {
-        Console.WriteLine($"[{ConsistantDateTimeFormat()}] {message}");
+        Console.WriteLine($"[{ConsistentDateTimeFormat()}] {message}");
     }
     public static void LogToConsole(string message, LogSeverity severity = LogSeverity.Info) 
     {
         ConsoleColor restoreColour = Console.ForegroundColor;
         SetConsoleColour(severity);
 
-        Console.WriteLine($"[{ConsistantDateTimeFormat()}] {message} [{severity}]");
+        Console.WriteLine($"[{ConsistentDateTimeFormat()}] {message} [{severity}]");
 
         Console.ForegroundColor = restoreColour;
     }

--- a/DiscordBot/Services/UnityHelp/Components/HelpBotMessage.cs
+++ b/DiscordBot/Services/UnityHelp/Components/HelpBotMessage.cs
@@ -1,0 +1,21 @@
+namespace DiscordBot.Services.UnityHelp;
+
+public enum HelpMessageType
+{
+    NoTags,
+    QuestionLength,
+    AllCapTitle, // Currently toLowers ALL CAP titles
+    HelpInTitle, // Currently unused
+}
+
+public class HelpBotMessage
+{
+    public ulong MessageId { get; set; }
+    public HelpMessageType Type { get; set; }
+    
+    public HelpBotMessage(ulong messageId, HelpMessageType type)
+    {
+        MessageId = messageId;
+        Type = type;
+    }
+}

--- a/DiscordBot/Services/UnityHelp/Components/ThreadContainer.cs
+++ b/DiscordBot/Services/UnityHelp/Components/ThreadContainer.cs
@@ -1,0 +1,28 @@
+namespace DiscordBot.Services.UnityHelp;
+
+public class ThreadContainer
+{
+    public ulong Owner { get; set; }
+    public ulong FirstUserMessage { get; set; }
+    public ulong ThreadId { get; set; }
+    public ulong LatestUserMessage { get; set; }
+    public ulong PinnedAnswer { get; set; }
+
+    public bool IsResolved { get; set; } = false;
+    public bool HasInteraction { get; set; } = false;
+    
+    
+    public ulong BotsLastMessage { get; set; }
+    public CancellationTokenSource CancellationToken { get; set; }
+    public DateTime ExpectedShutdownTime { get; set; }
+    
+    /// <summary>
+    /// Any message the bot sends that could need to be tracked/deleted later is stored here.
+    /// </summary>
+    public Dictionary<HelpMessageType, HelpBotMessage> HelpMessages { get; set; } = new();
+    
+    public bool HasMessage(HelpMessageType type) => HelpMessages.ContainsKey(type);
+    public ulong GetMessageId(HelpMessageType type) => HelpMessages[type].MessageId;
+    public void AddMessage(HelpMessageType type, ulong messageId) => HelpMessages.Add(type, new HelpBotMessage(messageId, type));
+    public void RemoveMessage(HelpMessageType type) => HelpMessages.Remove(type);
+}

--- a/DiscordBot/Services/UnityHelp/UnityHelpService.cs
+++ b/DiscordBot/Services/UnityHelp/UnityHelpService.cs
@@ -1,58 +1,10 @@
-using System.Net.Http.Headers;
 using Discord.WebSocket;
 using DiscordBot.Settings;
-using MessageExtensions = DiscordBot.Extensions.MessageExtensions;
+using DiscordBot.Services.UnityHelp;
 
 namespace DiscordBot.Services;
 
-public enum HelpMessageType
-{
-    NoTags,
-    QuestionLength,
-    AllCapTitle, // Currently toLowers ALL CAP titles
-    HelpInTitle, // Currently unused
-}
-
-public class HelpBotMessage
-{
-    public ulong MessageId { get; set; }
-    public HelpMessageType Type { get; set; }
-    
-    public HelpBotMessage(ulong messageId, HelpMessageType type)
-    {
-        MessageId = messageId;
-        Type = type;
-    }
-}
-
 // TODO : (James) Better Slash Command Support
-
-public class ThreadContainer
-{
-    public ulong Owner { get; set; }
-    public ulong FirstUserMessage { get; set; }
-    public ulong ThreadId { get; set; }
-    public ulong LatestUserMessage { get; set; }
-    public ulong PinnedAnswer { get; set; }
-
-    public bool IsResolved { get; set; } = false;
-    public bool HasInteraction { get; set; } = false;
-    
-    
-    public ulong BotsLastMessage { get; set; }
-    public CancellationTokenSource CancellationToken { get; set; }
-    public DateTime ExpectedShutdownTime { get; set; }
-    
-    /// <summary>
-    /// Any message the bot sends that could need to be tracked/deleted later is stored here.
-    /// </summary>
-    public Dictionary<HelpMessageType, HelpBotMessage> HelpMessages { get; set; } = new();
-    
-    public bool HasMessage(HelpMessageType type) => HelpMessages.ContainsKey(type);
-    public ulong GetMessageId(HelpMessageType type) => HelpMessages[type].MessageId;
-    public void AddMessage(HelpMessageType type, ulong messageId) => HelpMessages.Add(type, new HelpBotMessage(messageId, type));
-    public void RemoveMessage(HelpMessageType type) => HelpMessages.Remove(type);
-}
 
 public class UnityHelpService
 {

--- a/DiscordBot/Services/UnityHelp/UnityHelpService.cs
+++ b/DiscordBot/Services/UnityHelp/UnityHelpService.cs
@@ -620,12 +620,12 @@ public class UnityHelpService
         if (!_activeThreads.TryGetValue(channel.Id, out var thread))
             return "Invalid Thread";
 
-        if (IsValidAuthorUser(requester as SocketGuildUser, thread.Owner))
+        if (!IsValidAuthorUser(requester as SocketGuildUser, thread.Owner))
         {
-            
+            if (thread.Owner != requester.Id)
+                return "You are not the owner of this thread";
+            return "You can't do that!";
         }
-        if (thread.Owner != requester.Id)
-            return "You are not the owner of this thread";
         if (message.Author.Id == requester.Id)
             return "You cannot mark your own message as the answer";
 
@@ -699,15 +699,14 @@ public class UnityHelpService
     {
         if (user == null || user.IsUserBotOrWebhook())
             return false;
-        if (user.Id != authorId)
-        {
-            // If the user is moderator they can act on behalf of the author
-            if (user.HasRoleGroup(ModeratorRole))
-                return true;
-            return false;
-        }
+        
+        if (user.Id == authorId) return true;
+        // If the user is moderator they can act on behalf of the author
+        if (user.HasRoleGroup(ModeratorRole))
+            return true;
+        
+        return false;
 
-        return true;
     }
 
     #endregion // Utility Methods

--- a/DiscordBot/Services/UnityHelpService.cs
+++ b/DiscordBot/Services/UnityHelpService.cs
@@ -38,7 +38,7 @@ public class UnityHelpService
     
     private static readonly Emoji ThumbUpEmoji = new Emoji("👍");
     
-    private const int TimeBeforeClosedForResolvedTag = 5;
+    private const int TimeBeforeClosedForResolvedTag = 10;
     private readonly Embed _resolvedWarnOfPendingCloseEmbedHasPin = new EmbedBuilder()
         .WithTitle($"Issue Resolved")
         .WithDescription($"This issue has been marked as resolved and will be archived in {TimeBeforeClosedForResolvedTag} minutes.")
@@ -57,7 +57,7 @@ public class UnityHelpService
     private const string HasResponseExtraMessage = $"If you still need help, perhaps include additional details!";
     private static readonly Emoji CloseEmoji = new Emoji(":lock:");
 
-    private const int NoResponseNotResolvedIdleTime = 10; // 60 * 24 * 2;
+    private const int NoResponseNotResolvedIdleTime = 60 * 24 * 2;
     private readonly Embed _stealthDeleteEmbed = new EmbedBuilder()
         .WithTitle("Warning: No Activity")
         .WithDescription($"This question has been idle for {NoResponseNotResolvedIdleTime / 60} hours and has no response.\n" +
@@ -65,7 +65,7 @@ public class UnityHelpService
                          $"otherwise it will be closed in {StealthDeleteTime / 60} hours.")
         .WithColor(Color.LightOrange)
         .Build();
-    private const int StealthDeleteTime = 10; // 60 * 5;
+    private const int StealthDeleteTime = 60 * 5;
     
     private readonly Embed _noAppliedTagsEmbed = new EmbedBuilder()
         .WithTitle("Warning: No Tags Applied")

--- a/DiscordBot/Services/UnityHelpService.cs
+++ b/DiscordBot/Services/UnityHelpService.cs
@@ -1,0 +1,568 @@
+using System.Net.Http.Headers;
+using Discord.WebSocket;
+using DiscordBot.Settings;
+using MessageExtensions = DiscordBot.Extensions.MessageExtensions;
+
+namespace DiscordBot.Services;
+
+public class ThreadContainer
+{
+    public ulong Owner { get; set; }
+    public ulong FirstMessage { get; set; }
+    public ulong ChannelId { get; set; }
+    public ulong LatestMessage { get; set; }
+
+    public bool IsResolved { get; set; } = false;
+    public bool HasInteraction { get; set; } = false;
+    
+    
+    public ulong BotsLastMessage { get; set; }
+    public CancellationTokenSource CancellationToken { get; set; }
+    public DateTime ExpectedShutdownTime { get; set; }
+    
+    // Additional Helpful ids
+    public ulong NoAppliedTagsMessage { get; set; } = 0;
+    public ulong WarningMessage { get; set; } = 0;
+}
+
+public class UnityHelpService
+{
+    private readonly DiscordSocketClient _client;
+    private readonly ILoggingService _logging;
+    
+    #region Configuration
+    
+    private const int TimeBeforeClosedForResolvedTag = 1;
+    private static readonly string ResolvedWarnOfPendingCloseMessage = $"This issue has been marked as resolved and will be archived in {TimeBeforeClosedForResolvedTag} minutes.";
+    
+    private const int HasResponseIdleTimeSelfUser = 60 * 4;
+    private static readonly string HasResponseIdleTimeSelfUserMessage = $"Hello {{0}}! This forum has been inactive for {HasResponseIdleTimeSelfUser / 60} hours. If the question has been appropriately answered, click the {CloseEmoji} emoji to close this thread.";
+    private const int HasResponseIdleTimeOtherUser = 60 * 8;
+    private static readonly string HasResponseMessageRequestClose = $"Hello {{0}}! This forum has been inactive for {HasResponseIdleTimeOtherUser / 60} hours without your input. If the question has been appropriately answered, click the {CloseEmoji} emoji to close this thread.";
+    private const string HasResponseExtraMessage = $"If you still need help, perhaps include additional details!";
+    private static readonly Emoji CloseEmoji = new Emoji(":lock:");
+
+    private const int NoResponseNotResolvedIdleTime = 1; // 60 * 24 * 2;
+    private static readonly string StealthDeleteMessage = $"This question has been idle for {NoResponseNotResolvedIdleTime / 60} hours and has no response, it will be closed in {StealthDeleteTime / 60} hours if no other activity is detected.";
+    private const int StealthDeleteTime = 2; // 60 * 5;
+    
+    private static readonly string NoAppliedTagsUsed = $"It looks like you haven't applied any tags to this thread, be sure to include the appropriate tags to help others find your thread!";
+    
+    private const int MinimumLengthMessage = 40;
+    private readonly Embed _minimumLengthMessageEmbed = new EmbedBuilder()
+        .WithTitle("Warning: Short Question!")
+        .WithDescription($"Your question is short and may be difficult to answer! [don't ask to ask](https://dontasktoask.com/)!\n" +
+                         $"- Errors? Include full error message.\n" +
+                         $"- Features? Which version of Unity.\n" +
+                         $"- Assets? Relevant store links.")
+        .WithFooter("Be descriptive of the problem!")
+        .WithColor(Color.LightOrange)
+        .Build();
+
+    #endregion // Configuration
+
+    #region Extra Details
+    
+    private readonly IForumChannel _helpChannel;
+    
+    private const string ResolvedTag = "Resolved";
+    private readonly ForumTag _resolvedForumTag;
+
+    #endregion // Extra Details
+
+    public UnityHelpService(DiscordSocketClient client, BotSettings settings, ILoggingService logging)
+    {
+        _client = client;
+        _logging = logging;
+
+        // get the help channel settings.GenericHelpChannel
+        _helpChannel = _client.GetChannel(settings.GenericHelpChannel.Id) as IForumChannel;
+        if (_helpChannel == null)
+        {
+            LoggingService.LogToConsole("[UnityHelpService] Help channel not found", LogSeverity.Error);
+        }
+        var resolvedTag = _helpChannel.Tags.FirstOrDefault(x => x.Name == ResolvedTag);
+        _resolvedForumTag = resolvedTag;
+
+        // on reaction added, call method
+        _client.ReactionAdded += OnReactionAdded;
+
+        _client.ThreadCreated += GatewayOnThreadCreated;
+        _client.ThreadUpdated += GatewayOnThreadUpdated;
+        _client.ThreadDeleted += GatewayOnThreadDeleted;
+        _client.ThreadMemberJoined += GatewayOnThreadMemberJoinedThread;
+        _client.ThreadMemberLeft += GatewayOnThreadMemberLeftThread;
+        
+        _client.MessageReceived += GatewayOnMessageReceived;
+        _client.MessageUpdated += GatewayOnMessageUpdated;
+
+        Task.Run(LoadActiveThreads);
+    }
+
+    private async Task LoadActiveThreads()
+    {
+        var _loadingActiveThreads = await GetHelpActiveThreads();
+        foreach (var thread in _loadingActiveThreads)
+        {
+            var threadContents = (await _client.GetChannelAsync(thread.Id)) as SocketThreadChannel;
+            var latestMessageId = (thread.MessageCount > 0 ? threadContents.GetMessagesAsync(1).FlattenAsync().Result.FirstOrDefault().Id : 0);
+            var threadOwner = threadContents.Owner.Id;
+            var threadContainer = new ThreadContainer
+            {
+                ChannelId = thread.Id,
+                LatestMessage = latestMessageId,
+                Owner = threadOwner,
+                // TODO : (James) Work out if this should be resolved/closed already or not
+                IsResolved = thread.AppliedTags.Contains(_resolvedForumTag.Id),
+            };
+
+            if (threadContainer.IsResolved)
+            {
+                // Run in new task so we don't block the other threads from being processed
+                Task.Run(() => CloseThreadInTime(threadContainer, ResolvedWarnOfPendingCloseMessage,
+                    TimeBeforeClosedForResolvedTag));
+            }
+            else
+            {
+                _activeThreads.Add(threadContainer.ChannelId, threadContainer);
+            }
+        }
+    }
+
+    #region Thread Tracking
+    
+    // Threads we're currently tracking
+    private Dictionary<ulong, ThreadContainer> _activeThreads = new();
+
+    #region Thread Creation
+    
+    private async Task OnThreadCreated(SocketThreadChannel thread)
+    {
+        ThreadContainer container = new()
+        {
+            ChannelId = thread.Id,
+            LatestMessage = 0,
+            Owner = thread.Owner.Id,
+        };
+        _activeThreads.Add(thread.Id, container);
+        
+        // Check message length and inform user if too short
+        var firstMessage = (await thread.GetMessagesAsync(1).FlattenAsync()).FirstOrDefault();
+        container.FirstMessage = firstMessage!.Id;
+        if (firstMessage.Content.Length < MinimumLengthMessage)
+        {
+            var botResponse = await thread.SendMessageAsync(embed: _minimumLengthMessageEmbed);
+            container.WarningMessage = botResponse.Id;
+        }
+
+        // If not tags attached, let them know they should add some
+        if (thread.AppliedTags.Count == 0)
+        {
+            var botResponse = await thread.SendMessageAsync(NoAppliedTagsUsed);
+            container.NoAppliedTagsMessage = botResponse.Id;
+        }
+
+        // TODO : (James) Should we push this into a Task.Run?
+        // Sets up the thread to be closed after a certain amount of time (This will quickly be removed if anyone interacts with the thread)
+        await StealthDeleteThreadInTime(container);
+    }
+    
+    private async Task GatewayOnThreadCreated(SocketThreadChannel thread)
+    {
+        if (thread.ParentChannel.Id != _helpChannel.Id)
+            return;
+        if (thread.Owner.IsBot)
+            return;
+        // Gateway is called twice for forums, not sure why
+        if (_activeThreads.ContainsKey(thread.Id))
+            return;
+        
+        LoggingService.DebugLog($"[UnityHelpService] New Thread Created: {thread.Id} - {thread.Name}", LogSeverity.Debug);
+        Task.Run(() => OnThreadCreated(thread));
+    }
+    
+    #endregion // Thread Creation
+
+    #region Thread Update
+
+    private async Task OnThreadUpdated(SocketThreadChannel before, SocketThreadChannel after)
+    {
+        var thread = _activeThreads[after.Id];
+
+        // If the user was informed to add tags and they add some, we revoke the message
+        if (thread.NoAppliedTagsMessage != 0 && before.AppliedTags.Count < after.AppliedTags.Count)
+        {
+            var message = await after.GetMessageAsync(thread.NoAppliedTagsMessage);
+            if (message != null)
+                await message.DeleteAsync();
+            thread.NoAppliedTagsMessage = 0;
+        }
+
+        //! Handle when the thread gets resolve tag added to it
+        bool isNewResolved = !before.AppliedTags.Contains(_resolvedForumTag.Id) &&
+                             after.AppliedTags.Contains(_resolvedForumTag.Id);
+        if (isNewResolved)
+        {
+            // Posts a message in chat and closes the channel after x minutes
+            thread.IsResolved = true;
+            if (_activeThreads.TryGetValue(after.Id, out thread))
+            {
+                await CloseThreadInTime(thread, ResolvedWarnOfPendingCloseMessage, TimeBeforeClosedForResolvedTag);
+            }
+        }
+
+        // TODO : (James)
+        // //! Handle when the thread was resolved, but has been changed to unresolved
+        // if (before.AppliedTags.Contains(_resolvedForumTag.Id) &&
+        //     !after.AppliedTags.Contains(_resolvedForumTag.Id))
+        // {
+        //
+        // }
+    }
+    
+    private async Task GatewayOnThreadUpdated(Cacheable<SocketThreadChannel, ulong> before, SocketThreadChannel after)
+    {
+        if (after.ParentChannel.Id != _helpChannel.Id)
+            return;
+        if (!_activeThreads.TryGetValue(after.Id, out var thread))
+            return;
+
+        SocketThreadChannel beforeThread = await before.GetOrDownloadAsync();
+        SocketThreadChannel afterThread = after;
+        
+        LoggingService.DebugLog($"[UnityHelpService] Thread Updated: {after.Id} - {after.Name}", LogSeverity.Debug);
+        
+        Task.Run(async () => OnThreadUpdated(beforeThread, afterThread));
+    }
+    
+    #endregion // Thread Update
+
+    #region Thread Deleted
+    
+    private async Task OnThreadDeleted(SocketThreadChannel channel)
+    {
+        var thread = _activeThreads[channel.Id];
+        _activeThreads.Remove(channel.Id);
+
+        // Cancel any pending tasks
+        thread.CancellationToken?.Cancel();
+    }
+
+    private async Task GatewayOnThreadDeleted(Cacheable<SocketThreadChannel, ulong> threadId)
+    {
+        if (!_activeThreads.ContainsKey(threadId.Id))
+            return;
+        
+        LoggingService.DebugLog($"[UnityHelpService] Thread Deleted: {threadId.Id}", LogSeverity.Debug);
+
+        Task.Run(async () => OnThreadDeleted(await threadId.GetOrDownloadAsync()));
+    }
+    
+    #endregion // Thread Deleted
+
+    #region User Joins/Leaves Thread
+    
+    private async Task GatewayOnThreadMemberJoinedThread(SocketThreadUser user)
+    {
+        if (user.Thread.Id != _helpChannel.Id)
+            return;
+
+        if (!_activeThreads.TryGetValue(user.Thread.Id, out var thread))
+            return;
+
+        thread.HasInteraction = true;
+    }
+
+    private async Task GatewayOnThreadMemberLeftThread(SocketThreadUser user)
+    {
+        if (user.Thread.Id != _helpChannel.Id)
+            return;
+        
+        // TODO : (James) Check if user was author? If so, close thread?
+    }
+    
+    #endregion // User Joins/Leaves Thread
+
+    #region Message Received
+    
+    private async Task OnMessageReceived(SocketMessage message)
+    {
+        var thread = _activeThreads[message.Channel.Id];
+        
+        thread.LatestMessage = message.Id;
+        // If Author is only one who has interacted with the thread, we don't need to update anything else
+        if (!thread.HasInteraction && message.Author.Id == thread.Owner)
+            return;
+        
+        thread.HasInteraction = true;
+        
+        var channel = message.Channel as SocketThreadChannel;
+        if (channel.Owner.Id == message.Author.Id)
+        {
+            await RequestThreadShutdownInTime(thread, HasResponseIdleTimeSelfUserMessage + HasResponseExtraMessage, HasResponseIdleTimeSelfUser);
+            return;
+        }
+        else
+        {
+            await RequestThreadShutdownInTime(thread, HasResponseMessageRequestClose + HasResponseExtraMessage, HasResponseIdleTimeOtherUser);
+            return;
+        }
+    }
+    
+    private async Task GatewayOnMessageReceived(SocketMessage message)
+    {
+        if (message.Channel.Id != _helpChannel.Id)
+            return;
+        if (message.Author.IsBot)
+            return;
+        if (!_activeThreads.TryGetValue(message.Channel.Id, out var thread))
+            return;
+        
+        LoggingService.DebugLog($"[UnityHelpService] Help Message Received: {message.Id} - {message.Content}", LogSeverity.Debug);
+        Task.Run(() => OnMessageReceived(message));
+    }
+
+    private async Task OnMessageUpdated(IMessage before, IMessage after, SocketThreadChannel channel)
+    {
+        var thread = _activeThreads[channel.Id];
+        
+        if (thread.WarningMessage != 0 && before.Id == thread.FirstMessage)
+        {
+            if (after.Content.Length > MinimumLengthMessage)
+            {
+                var warningMessage = await channel.GetMessageAsync(thread.WarningMessage);
+                if (warningMessage != null)
+                    await warningMessage.DeleteAsync();
+                thread.WarningMessage = 0;
+            }
+        }
+    }
+    
+    private async Task GatewayOnMessageUpdated(Cacheable<IMessage, ulong> before, SocketMessage after, ISocketMessageChannel channel)
+    {
+        if (channel is not SocketThreadChannel)
+            return;
+        if (((SocketThreadChannel)channel).ParentChannel.Id != _helpChannel.Id)
+            return;
+        if (after.Author.IsBot)
+            return;
+        if (!_activeThreads.TryGetValue(channel.Id, out var thread))
+            return;
+        if (thread.Owner != after.Author.Id)
+            return;
+        
+        var beforeMsg = await before.GetOrDownloadAsync();
+        if (beforeMsg == null)
+            return;
+
+        LoggingService.DebugLog($"[UnityHelpService] Help Message Updated: {after.Id} - {after.Content}", LogSeverity.Debug);
+        Task.Run(() => OnMessageUpdated(beforeMsg, after, channel as SocketThreadChannel));
+    }
+
+    #endregion // Message Received
+    
+    #endregion // Thread Tracking
+
+    #region Event Handlers
+
+    private async Task OnReactionAdded(Cacheable<IUserMessage, ulong> messageCache, Cacheable<IMessageChannel, ulong> channelChache, SocketReaction reaction)
+    {
+        // Check if reaction is in a proper thread/forum and not just a normal message
+        if (await channelChache.GetOrDownloadAsync() is not SocketThreadChannel channel || channel.Id != _helpChannel.Id)
+            return;
+        var message = await messageCache.GetOrDownloadAsync();
+        // Limit locking to only reactions on the bots messages
+        if (message == null || message.Author.Id != _client.CurrentUser.Id)
+            return;
+
+        Task.Run(async () =>
+        {
+            // Check the owner is the one reacting
+            var threadOwner = channel.Owner.Id;
+            if (reaction.UserId != threadOwner)
+                return;
+
+            await CloseThread(channel, true);
+        });
+    }
+
+    #endregion // Event Handlers
+
+    #region Bulk Behaviour Handler
+
+        private async Task CloseThreadInTime(ThreadContainer thread, string message, int minutes)
+    {
+        if (!(await IsValidThread(thread)))
+            return;
+        
+        var expectedShutdownTime = DateTime.Now.AddMinutes(minutes);
+        var threadChannel = _client.GetChannel(thread.ChannelId) as SocketThreadChannel;
+        // Check if token already created, each thread shares its own token with any relevant action (close, delete, etc)
+        await CancelPreviousWarning(thread, expectedShutdownTime);
+        
+        thread.CancellationToken ??= new CancellationTokenSource();
+        // Send our message
+        if (!string.IsNullOrEmpty(message))
+        {
+            await threadChannel.SendMessageAsync(message);
+        }
+        thread.ExpectedShutdownTime = expectedShutdownTime;
+        await Task.Delay(minutes * 60 * 1000, thread.CancellationToken.Token);
+        if (await IsTaskCancelled(thread))
+            return;
+
+        await CloseThread(threadChannel!, thread.IsResolved);
+    }
+
+    private async Task RequestThreadShutdownInTime(ThreadContainer thread, string msgString, int minutes)
+    {
+        if (!(await IsValidThread(thread)))
+            return;
+        
+        var expectedWarnTime = DateTime.Now.AddMinutes(minutes);
+        var threadChannel = _client.GetChannel(thread.ChannelId) as SocketThreadChannel;
+        // Check if token already created, each thread shares its own token with any relevant action (close, delete, etc)
+        await CancelPreviousWarning(thread, expectedWarnTime);
+        thread.CancellationToken ??= new CancellationTokenSource();
+        
+        thread.ExpectedShutdownTime = expectedWarnTime;
+        await Task.Delay(minutes * 60 * 1000, thread.CancellationToken.Token);
+        if (await IsTaskCancelled(thread))
+            return;
+        
+        msgString = string.Format(msgString, threadChannel.Owner.Mention);
+        var sentMessage = await threadChannel.SendMessageAsync(msgString);
+        // add the lock reaction
+        await sentMessage.AddReactionAsync(CloseEmoji);
+        thread.LatestMessage = sentMessage.Id;
+    }
+    
+    /// <summary>
+    /// When a thread is first started, this is called first to set it up to be closed after a certain amount of time
+    /// This will quickly be canceled if the thread is interacted with.
+    /// </summary>
+    private async Task StealthDeleteThreadInTime(ThreadContainer thread)
+    {
+        if (!(await IsValidThread(thread)))
+            return;
+        
+        var expectedShutdownTime = DateTime.Now.AddMinutes(NoResponseNotResolvedIdleTime);
+        var threadChannel = _client.GetChannel(thread.ChannelId) as SocketThreadChannel;
+
+        thread.CancellationToken ??= new CancellationTokenSource();
+        thread.ExpectedShutdownTime = expectedShutdownTime;
+        // Wait for the time to pass
+        await Task.Delay(NoResponseNotResolvedIdleTime * 60 * 1000, thread.CancellationToken.Token);
+        if (await IsTaskCancelled(thread))
+            return;
+
+        // We prompt chat that the thread is going to be deleted in x number of hours, which will double as a bump.
+        var botResponse = await threadChannel.SendMessageAsync(StealthDeleteMessage);
+        thread.BotsLastMessage = botResponse.Id;
+        
+        // Wait for the next set of time to pass
+        thread.ExpectedShutdownTime = DateTime.Now.AddMinutes(StealthDeleteTime);
+        await Task.Delay(StealthDeleteTime * 60 * 1000, thread.CancellationToken.Token);
+        if (await IsTaskCancelled(thread))
+            return;
+
+        await threadChannel.DeleteAsync();
+    }
+
+    #endregion // Bulk Behaviour Handler
+    
+    
+    #region Generic Methods
+    
+    private async Task CloseThread(IThreadChannel channel, bool includeResolvedTag = false)
+    {
+        var appliedTags = channel.AppliedTags.ToList();
+        if (includeResolvedTag && !appliedTags.Contains(_resolvedForumTag.Id))
+            appliedTags.Add(_resolvedForumTag.Id);
+        
+        await channel.ModifyAsync(x =>
+        {
+            x.Archived = true;
+            x.AppliedTags = appliedTags;
+        });
+
+        await EndThreadTracking(channel.Id);
+    }
+
+    private async Task EndThreadTracking(ThreadContainer thread)
+    {
+        thread.CancellationToken?.Cancel();
+        _activeThreads.Remove(thread.ChannelId);
+    }
+    private async Task EndThreadTracking(ulong threadId)
+    {
+        if (_activeThreads.TryGetValue(threadId, out var thread))
+            await EndThreadTracking(thread);
+    }
+
+    // Check if token already created, each thread shares its own token with any relevant action (close, delete, etc)
+    private async Task CancelPreviousWarning(ThreadContainer thread, DateTime newShutdownTime)
+    {
+        if (thread.CancellationToken != null)
+        {
+            if (thread.ExpectedShutdownTime < newShutdownTime)
+            {
+                thread.CancellationToken.Cancel();
+                thread.CancellationToken = null;
+            }
+            await RemoveContainerPreviousComment(thread);
+        }
+    }
+    
+    private async Task<List<IThreadChannel>> GetHelpActiveThreads()
+    {
+        var messages = await _helpChannel.GetActiveThreadsAsync();
+        var helpThreads = messages.Where(x => x.CategoryId == _helpChannel.Id).ToList();
+        return helpThreads;
+    }
+
+    #endregion // Generic Methods
+
+    #region Utility Methods
+
+    private async Task RemoveContainerPreviousComment(ThreadContainer thread)
+    {
+        if (thread.BotsLastMessage == 0)
+            return;
+        if (await _client.GetChannelAsync(thread.ChannelId) is SocketThreadChannel threadChannel)
+        {
+            var message = await threadChannel.GetMessageAsync(thread.BotsLastMessage);
+            if (message != null)
+            {
+                await message.DeleteAsync();
+            }
+        }
+    }
+
+    private async Task<bool> IsValidThread(ThreadContainer thread)
+    {
+        var threadChannel = _client.GetChannel(thread.ChannelId) as SocketThreadChannel;
+        // If channel is null, we have problems, we remove them from _activeThreads, cancel the token and return to avoid an exception
+        if (threadChannel == null)
+        {
+            await EndThreadTracking(thread);
+            return false;
+        }
+        return true;
+    }
+    
+    private async Task<bool> IsTaskCancelled(ThreadContainer thread)
+    {
+        if (thread.CancellationToken == null)
+            return false;
+        if (thread.CancellationToken.IsCancellationRequested)
+        {
+            LoggingService.DebugLog($"[UnityHelpService] Task cancelled for Channel {thread.ChannelId}");
+            return true;
+        }
+        return false;
+    }
+
+    #endregion // Utility Methods
+    
+}

--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -44,6 +44,8 @@ public class BotSettings
     #region Channels
     
     public GeneralChannel GeneralChannel { get; set; }
+    public GenericHelpChannel GenericHelpChannel { get; set; }
+    
     public BotAnnouncementChannel BotAnnouncementChannel { get; set; }
     public AnnouncementsChannel AnnouncementsChannel { get; set; }
     public BotCommandsChannel BotCommandsChannel { get; set; }
@@ -165,6 +167,11 @@ public class AutoThreadChannel
 
 public class GeneralChannel : ChannelInfo
 {
+}
+
+public class GenericHelpChannel : ChannelInfo
+{
+    
 }
 
 public class BotAnnouncementChannel : ChannelInfo

--- a/DiscordBot/Utils/Utils.cs
+++ b/DiscordBot/Utils/Utils.cs
@@ -139,6 +139,16 @@ public static class Utils
         }
         return DateTime.Now + timeSpan;
     }
+
+    /// <summary>
+    /// Very dirty way to strip html tags, removes anything inside &lt; and &gt; and replaces it with nothing
+    /// </summary>
+    public static string RemoveHtmlTags(string contents)
+    {
+        if (string.IsNullOrEmpty(contents)) return contents;
+        var regex = new Regex("<.*?>");
+        return regex.Replace(contents, string.Empty);
+    }
         
     public static string MessageLinkBack(ulong guildId, ulong channelId, ulong messageId)
     {


### PR DESCRIPTION
# Description
General purpose PR that is a little overscoped but encapsulates most of the required needs of a few forum related issues we currently have.

## RSS (#222)
- Moves all RSS into Unity-News (ID Variable which must be forum) and posts the feeds as forum/threads in that channel with the included tags and mention roles related.

![image](https://user-images.githubusercontent.com/8342701/195088089-01ec678b-5a0e-449d-b2a2-429eb4c776e1.png)

**Why**:  News is simple, it is more organized and digestable, as for the Beta/New releases, these are already ignored by 99% of people in the unity-discussion channel, at least now they'll be grouped into a place that if people do want to talk they can. The roles related will still be pinged.

## Bot Cleans up Posts (#223) ***WIP***
- When a question is started, it checks if any tags are included and asks the user to add some. (This message is deleted once a tag is added)
- When a question is started, if it is shorter than minimum expected (40 at time of writting) it'll post an embed telling the user details to hopefully improve their question, this will also be deleted if they edit their original post to be longer than 40 characters.
![image](https://user-images.githubusercontent.com/8342701/195089205-ba89cb7f-5b09-479f-94c8-ee40236b4aa7.png)
- Stealth Delete, if a user posts a question and it goes a defined time (3 days) a message bumping the question stating it is idle and will be deleted in x number of hours (5 at time of writing), this gives questions a chance to be answered even if they've been abandoned, otherwise if the message gets no interaction it is deleted so that it can not be discovered (hopefully to remove bloat from search history for future questions)

**TODO**:
- [ ] React track, depending on how many reactions a response gets, mark it as the answer and pin it within the forum.
*The above is partially done, Author/Moderators can mark an answer as correct and it will resolve the question, and pin the answer to improve visibility. A reaction is added to allow other users to also engage with support for the answer provided.*
- [x] Message Context -> Mark Resolve

## Command to help close posts (#221) ***WIP***
- After a message is responded to
  - if the author is the last person to chat, a 4 hour timer starts and the bot asks if the question has been answered giving them an emote to react to which will resolve the question and close it 10 minutes later.
  - if someone else is last person, an 8 hour timer starts to give the author time to see the chat and implement whatever, before posting the same message, both cases (4 and 8 hours) the author is pinged. These values may change later.

**TODO**:
- [x] Slash Command or Word command to resolve and close questions
*Mostly done, a slash command can be done to resolve the question which will begin the archive process, no command to simply "close" the question*

# Other information

# Relevant Issues
- Resolves #223 
- Resolves  #222 
- Resolves  #221