### PR TITLE
Fix - Replace dead Currency API

### DIFF
--- a/DiscordBot/Extensions/ContextExtension.cs
+++ b/DiscordBot/Extensions/ContextExtension.cs
@@ -1,0 +1,14 @@
+using Discord.Commands;
+
+namespace DiscordBot.Extensions;
+
+public static class ContextExtension
+{
+    /// <summary>
+    /// Returns true if the context includes a RoleID, UserID or Mentions Everyone (Should include @here, unsure)
+    /// </summary>
+    public static bool HasAnyPingableMention(this ICommandContext context)
+    {
+        return context.Message.MentionedUserIds.Count > 0 || context.Message.MentionedRoleIds.Count > 0 || context.Message.MentionedEveryone;
+    }
+}

--- a/DiscordBot/Extensions/MessageExtensions.cs
+++ b/DiscordBot/Extensions/MessageExtensions.cs
@@ -14,4 +14,12 @@ public static class MessageExtensions
         }
         return true;
     }
+    
+    /// <summary>
+    /// Returns true if the message includes any RoleID's, UserID's or Mentions Everyone
+    /// </summary>
+    public static bool HasAnyPingableMention(this IUserMessage message)
+    {
+        return message.MentionedUserIds.Count > 0 || message.MentionedRoleIds.Count > 0 || message.MentionedEveryone;
+    }
 }

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -1073,6 +1073,9 @@ public class UserModule : ModuleBase
     [Alias("curr")]
     public async Task ConvertCurrency(double amount, string from, string to = "usd")
     {
+        if (Context.HasAnyPingableMention())
+            return;
+        
         from = from.ToLower();
         to = to.ToLower();
 
@@ -1083,19 +1086,19 @@ public class UserModule : ModuleBase
         // Check if valid
         if (!fromValid || !toValid)
         {
-            await ReplyAsync("One of the currencies provided is invalid.");
+            await Context.Message.ReplyAsync("One of the currencies provided is invalid.");
             return;
         }
 
         var response = await CurrencyService.GetConversion(to, from);
         if (Math.Abs(response - (-1)) < 0.01)
         {
-            await ReplyAsync("An error occured while converting the currency, the API may be down!");
+            await Context.Message.ReplyAsync("An error occured while converting the currency, the API may be down!");
             return;
         }
 
         var totalAmount = Math.Round(amount * response, 2);
-        await ReplyAsync($"**{amount} {from.ToUpper()}** = **{totalAmount} {to.ToUpper()}**");
+        await Context.Message.ReplyAsync($"**{amount} {from.ToUpper()}** = **{totalAmount} {to.ToUpper()}**");
     }
 
     #endregion

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -1059,6 +1059,19 @@ public class UserModule : ModuleBase
     #endregion
 
     #region Currency
+    
+    [Command("CurrencyName") , Priority(29)]
+    [Summary("Get the name of a currency. Syntax : !currname USD")]
+    [Alias("currname")]
+    public async Task CurrencyName(string currency)
+    {
+        if (Context.HasAnyPingableMention())
+            return;
+        var name = await CurrencyService.GetCurrencyName(currency);
+        if (name == string.Empty)
+            await Context.Message.ReplyAsync($"Sorry, I couldn't find the name of the currency **{currency}**.");
+        await Context.Message.ReplyAsync($"The name of the currency **{currency.ToUpper()}** is **{name}**.");
+    }
 
     [Command("Currency"), HideFromHelp]
     [Summary("Converts a currency. Syntax : !currency fromCurrency toCurrency")]

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -1063,7 +1063,7 @@ public class UserModule : ModuleBase
     [Command("Currency"), HideFromHelp]
     [Summary("Converts a currency. Syntax : !currency fromCurrency toCurrency")]
     [Alias("curr")]
-    public async Task ConvertCurrency(string from, string to)
+    public async Task ConvertCurrency(string from, string to = "usd")
     {
         await ConvertCurrency(1, from, to);
     }
@@ -1071,59 +1071,31 @@ public class UserModule : ModuleBase
     [Command("Currency"), Priority(29)]
     [Summary("Converts a currency. Syntax : !currency amount fromCurrency toCurrency")]
     [Alias("curr")]
-    public async Task ConvertCurrency(double amount, string from, string to)
+    public async Task ConvertCurrency(double amount, string from, string to = "usd")
     {
-        from = from.ToUpper();
-        to = to.ToUpper();
+        from = from.ToLower();
+        to = to.ToLower();
 
         // We check if both currencies are valid
-        bool fromValid = await CurrencyService.IsCurrency(from.ToUpper());
-        bool toValid = await CurrencyService.IsCurrency(to.ToUpper());
+        bool fromValid = await CurrencyService.IsCurrency(from.ToLower());
+        bool toValid = await CurrencyService.IsCurrency(to.ToLower());
         
-        // Response for invalid currencies
-        if (!await CurrencyFailedResponse((from, !fromValid), (to, !toValid)))
-            return;
-        
-        // Currency in USD
-        Rate fromRate =  await CurrencyService.GetRate(from);
-        Rate toRate =await CurrencyService.GetRate(to);
-
-        // Since currency must be valid we can assume the API is dead
-        if (fromRate == null || toRate == null)
+        // Check if valid
+        if (!fromValid || !toValid)
         {
-            var embedBuilder = new EmbedBuilder()
-                .WithTitle("Currency API Down")
-                .WithDescription(
-                    "Check [API Status](https://www.currencyconverterapi.com/server-status), and try again in a few minutes.")
-                .WithColor(Color.Red);
-            await ReplyAsync(embed: embedBuilder.Build()).DeleteAfterSeconds(seconds: 10);
+            await ReplyAsync("One of the currencies provided is invalid.");
             return;
         }
 
-        // Convert fromCurrency amount to USD to toCurrency
-        var value = Math.Round(toRate.Value / fromRate.Value * amount, 2);
-        bool isStaleConversion = (CurrencyService.IsCurrencyExpired(fromRate) || CurrencyService.IsCurrencyExpired(toRate));
-        await ReplyAsync($"{Context.User.Mention} **{amount} {from}** = **{value} {to}** {(isStaleConversion ? "*(stale)*" : "")}");
-    }
+        var response = await CurrencyService.GetConversion(to, from);
+        if (Math.Abs(response - (-1)) < 0.01)
+        {
+            await ReplyAsync("An error occured while converting the currency, the API may be down!");
+            return;
+        }
 
-    private async Task<bool> CurrencyFailedResponse((string name, bool invalid) from, (string name, bool invalid) to)
-    {
-        if (from.invalid && to.invalid)
-        {
-            await ReplyAsync($"{Context.User.Mention}, {from.name} and {to.name} are invalid currencies or incorrectly used.\nPlease use international currency code (example : **USD** for $, **EUR** for €, **PKR** for pakistani rupee).");
-            return false;
-        }
-        if (from.invalid)
-        {
-            await ReplyAsync($"{Context.User.Mention}, {from.name} is an invalid currency.");
-            return false;
-        }
-        if (to.invalid)
-        {
-            await ReplyAsync($"{Context.User.Mention}, {to.name} is an invalid currency.");
-            return false;
-        }
-        return true;
+        var totalAmount = Math.Round(amount * response, 2);
+        await ReplyAsync($"**{amount} {from.ToUpper()}** = **{totalAmount} {to.ToUpper()}**");
     }
 
     #endregion

--- a/DiscordBot/Services/CurrencyService.cs
+++ b/DiscordBot/Services/CurrencyService.cs
@@ -7,39 +7,36 @@ namespace DiscordBot.Services;
 
 public class CurrencyService
 {
-    private readonly Dictionary<string, Rate> _rates;
+    #region Configuration
 
-    private const string ApiKey = "&apiKey=5d733a03e0274dff3e7f";
-    private const string ApiBaseUrl = "https://free.currconv.com/api/v7/";
-    private const string ApiCurrencyConvert = "convert?q=USD_{0}&compact=ultra";
-    private const string ApiValidCurrency = "currencies?";
+    private const int ApiVersion = 1;
+    private const string ValidCurrenciesEndpoint = "currencies.min.json";
+    private const string ExchangeRatesEndpoint = "currencies";
     
-    // Dictionary of currencies as upper case. EUR, AUD, USD, BTC, etc.
-    private readonly Dictionary<string, bool> _validCurrencies = new Dictionary<string, bool>();
-    
-    public CurrencyService()
+    private class Currency
     {
-        _rates = new Dictionary<string, Rate>();
+        public string Name { get; set; }
+        public string Short { get; set; }
     }
 
-    public async Task<Rate> GetRate(string currency)
+    #endregion // Configuration
+    
+    private readonly Dictionary<string, Currency> _currencies = new Dictionary<string, Currency>();
+
+    private static readonly string ApiUrl = $"https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@{ApiVersion}/latest/";
+
+    public async Task<float> GetConversion(string toCurrency, string fromCurrency = "usd")
     {
-        if (!HasValidRate(currency))
-        {
-            try
-            {
-                var rate = await GetNewRate(currency);
-                if (rate != null)
-                    _rates[currency] = rate;
-            }
-            catch (Exception e)
-            {
-                if (_rates.ContainsKey(currency))
-                    return _rates[currency];
-            }
-        }
+        toCurrency = toCurrency.ToLower();
+        fromCurrency = fromCurrency.ToLower();
         
-        return _rates.ContainsKey(currency) ? _rates[currency] : null;
+        var url = $"{ApiUrl}{ExchangeRatesEndpoint}/{fromCurrency.ToLower()}/{toCurrency.ToLower()}.min.json";
+        var response = await GetResponse(url);
+        if (string.IsNullOrEmpty(response))
+            return -1;
+        
+        var json = JObject.Parse(response);
+        return json[$"{toCurrency}"].Value<float>();
     }
     
     #region Public Methods
@@ -47,9 +44,9 @@ public class CurrencyService
     // Checks if a provided currency is valid, it also checks is we have a list of currencies to check against and rebuilds it if not. (If the API was down when bot started)
     public async Task<bool> IsCurrency(string currency)
     {
-        if (_validCurrencies.Count == 0)
+        if (_currencies.Count  <= 1)
             await BuildCurrencyList();
-        return _validCurrencies.ContainsKey(currency);
+        return _currencies.ContainsKey(currency);
     }
 
     #endregion // Public Methods
@@ -58,16 +55,20 @@ public class CurrencyService
 
     private async Task BuildCurrencyList()
     {
-        var url = ApiBaseUrl + ApiValidCurrency + ApiKey;
-        var response = await new HttpClient().GetAsync(url);
+        var url = ApiUrl + ValidCurrenciesEndpoint;
+        var client = new HttpClient();
+        var response = await client.GetAsync(url);
         var json = await response.Content.ReadAsStringAsync();
         var currencies = JObject.Parse(json);
-        currencies = (JObject)currencies["results"];
         
-        foreach (var currency in currencies.Children())
+        // Json is weird format of `Code: Name` each in dependant ie; {"1inch":"1inch Network","aave":"Aave"}
+        foreach (var currency in currencies)
         {
-            var currencyName = currency.Path.Split('.')[1];
-            _validCurrencies.Add(currencyName.ToUpper(), true);
+            _currencies.Add(currency.Key, new Currency
+            {
+                Name = currency.Value!.ToString(),
+                Short = currency.Key
+            });
         }
     }
 
@@ -88,37 +89,4 @@ public class CurrencyService
 
     #endregion // Private Methods
 
-    private async Task<Rate> GetNewRate(string currency)
-    {
-        var result = await GetResponse(ApiBaseUrl + string.Format(ApiCurrencyConvert, currency) + ApiKey);
-        
-        if (string.IsNullOrEmpty(result) || result.Equals("{}")) return null;
-
-        var rate = new Rate
-        {
-            Value = (double)JObject.Parse(result)[$"USD_{currency}"],
-            Expires = DateTime.Now.AddHours(6)
-        };
-
-        return rate;
-    }
-
-    private bool HasValidRate(string currency) => _rates.ContainsKey(currency) && !IsCurrencyExpired(_rates[currency]);
-    
-    public static bool IsCurrencyExpired(Rate rate) => rate.Expires < DateTime.Today;
-    
-}
-
-public class Rate
-{
-    public DateTime Expires { get; set; }
-    public double Value { get; set; }
-
-    public Rate()
-    {
-        Value = -1;
-        Expires = DateTime.MinValue;
-    }
-    
-    public bool IsStale() => Expires < DateTime.Today;
 }

--- a/DiscordBot/Services/CurrencyService.cs
+++ b/DiscordBot/Services/CurrencyService.cs
@@ -40,7 +40,15 @@ public class CurrencyService
     }
     
     #region Public Methods
-    
+
+    public async Task<string> GetCurrencyName(string currency)
+    {
+        currency = currency.ToLower();
+        if (!await IsCurrency(currency))
+            return string.Empty;
+        return _currencies[currency].Name;
+    }
+
     // Checks if a provided currency is valid, it also checks is we have a list of currencies to check against and rebuilds it if not. (If the API was down when bot started)
     public async Task<bool> IsCurrency(string currency)
     {


### PR DESCRIPTION
# Description
Replaces the old API with something not bad.

Key changes:
- `!currname` 
- `!curr` will default to USD if no to currency provided
- API is no longer garbage
- Added extension for Context and Messages to allow a single call to check if any Mentions/Roles/Everyone is in context to avoid dangerous replies. (Allows bot to quickly check context and just ignore a comand if it has mentions)