### PR TITLE
Fix - Convert initial DB Test to be async

### DIFF
--- a/DiscordBot/Extensions/UserDBRepository.cs
+++ b/DiscordBot/Extensions/UserDBRepository.cs
@@ -65,5 +65,5 @@ public interface IServerUserRepo
 
     /// <summary>Returns a count of users in the Table, otherwise it fails. </summary>
     [Sql("SELECT COUNT(*) FROM users")]
-    long TestConnection();
+    Task<long> TestConnection();
 }

--- a/DiscordBot/Services/DatabaseService.cs
+++ b/DiscordBot/Services/DatabaseService.cs
@@ -33,34 +33,46 @@ public class DatabaseService
             return;
         }
 
-        // Test connection, if it fails we create the table and set keys
-        try
+        Task.Run(async () =>
         {
-            _connection.TestConnection();
-        }
-        catch (Exception)
-        {
-            LoggingService.LogToConsole("DatabaseService: Table 'users' does not exist, attempting to generate table.", LogSeverity.Warning);
-            c.ExecuteSql(
-"CREATE TABLE `users` (`ID` int(11) UNSIGNED  NOT NULL, `UserID` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL, `Karma` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaWeekly` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaMonthly` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaYearly` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaGiven` int(11) UNSIGNED NOT NULL DEFAULT 0, `Exp` bigint(11) UNSIGNED  NOT NULL DEFAULT 0, `Level` int(11) UNSIGNED NOT NULL DEFAULT 0) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
-            c.ExecuteSql("ALTER TABLE `users` ADD PRIMARY KEY (`ID`,`UserID`), ADD UNIQUE KEY `UserID` (`UserID`)");
-            c.ExecuteSql("ALTER TABLE `users` MODIFY `ID` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=1");
-            LoggingService.LogToConsole("DatabaseService: Table 'users' generated without errors.", LogSeverity.Info);
-        }
-        // Generate and add events if they don't exist
-        try
-        {
-            c.ExecuteSql(
-                $"CREATE EVENT IF NOT EXISTS `ResetWeeklyLeaderboards` ON SCHEDULE EVERY 1 WEEK STARTS '2021-08-02 00:00:00' ON COMPLETION NOT PRESERVE ENABLE DO UPDATE {c.Database}.users SET KarmaWeekly = 0");
-            c.ExecuteSql(
-                $"CREATE EVENT IF NOT EXISTS `ResetMonthlyLeaderboards` ON SCHEDULE EVERY 1 MONTH STARTS '2021-08-01 00:00:00' ON COMPLETION NOT PRESERVE ENABLE DO UPDATE {c.Database}.users SET KarmaMonthly = 0");
-            c.ExecuteSql(
-                $"CREATE EVENT IF NOT EXISTS `ResetYearlyLeaderboards` ON SCHEDULE EVERY 1 YEAR STARTS '2022-01-01 00:00:00' ON COMPLETION NOT PRESERVE ENABLE DO UPDATE {c.Database}.users SET KarmaYearly = 0");
-        }
-        catch (Exception e)
-        {
-            LoggingService.LogToConsole($"SQL Exception: Failed to generate leaderboard events.\nMessage: {e}", LogSeverity.Warning);
-        }
+            // Test connection, if it fails we create the table and set keys
+            try
+            {
+                var userCount = await _connection.TestConnection();
+                await _logging.LogAction($"DatabaseService: Connected to database successfully. {userCount} users in database.");
+            }
+            catch (Exception)
+            {
+                LoggingService.LogToConsole(
+                    "DatabaseService: Table 'users' does not exist, attempting to generate table.",
+                    LogSeverity.Warning);
+                c.ExecuteSql(
+                    "CREATE TABLE `users` (`ID` int(11) UNSIGNED  NOT NULL, `UserID` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL, `Karma` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaWeekly` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaMonthly` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaYearly` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaGiven` int(11) UNSIGNED NOT NULL DEFAULT 0, `Exp` bigint(11) UNSIGNED  NOT NULL DEFAULT 0, `Level` int(11) UNSIGNED NOT NULL DEFAULT 0) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+                c.ExecuteSql("ALTER TABLE `users` ADD PRIMARY KEY (`ID`,`UserID`), ADD UNIQUE KEY `UserID` (`UserID`)");
+                c.ExecuteSql(
+                    "ALTER TABLE `users` MODIFY `ID` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=1");
+                LoggingService.LogToConsole("DatabaseService: Table 'users' generated without errors.",
+                    LogSeverity.Info);
+                c.Close();
+            }
+
+            // Generate and add events if they don't exist
+            try
+            {
+                c.ExecuteSql(
+                    $"CREATE EVENT IF NOT EXISTS `ResetWeeklyLeaderboards` ON SCHEDULE EVERY 1 WEEK STARTS '2021-08-02 00:00:00' ON COMPLETION NOT PRESERVE ENABLE DO UPDATE {c.Database}.users SET KarmaWeekly = 0");
+                c.ExecuteSql(
+                    $"CREATE EVENT IF NOT EXISTS `ResetMonthlyLeaderboards` ON SCHEDULE EVERY 1 MONTH STARTS '2021-08-01 00:00:00' ON COMPLETION NOT PRESERVE ENABLE DO UPDATE {c.Database}.users SET KarmaMonthly = 0");
+                c.ExecuteSql(
+                    $"CREATE EVENT IF NOT EXISTS `ResetYearlyLeaderboards` ON SCHEDULE EVERY 1 YEAR STARTS '2022-01-01 00:00:00' ON COMPLETION NOT PRESERVE ENABLE DO UPDATE {c.Database}.users SET KarmaYearly = 0");
+                c.Close();
+            }
+            catch (Exception e)
+            {
+                LoggingService.LogToConsole($"SQL Exception: Failed to generate leaderboard events.\nMessage: {e}",
+                    LogSeverity.Warning);
+            }
+        });
     }
 
     public async Task FullDbSync(IGuild guild, IUserMessage message)


### PR DESCRIPTION
I think the lib we're using expects non-async calls to be closed externally, how I've setup the test to run now is a bit eh, and may result in a race condition in the future if more complicated database stuff is added on first boot, but unsure.

How it is now does appear to close everything, so I'm unsure if we'll still run into issues with !profile or !top time will tell though.