### PR TITLE
Feat: Misc Fixes & Recruitment Channel BabySitter

### DIFF
--- a/DiscordBot/Extensions/UserExtensions.cs
+++ b/DiscordBot/Extensions/UserExtensions.cs
@@ -17,4 +17,29 @@ public static class UserExtensions
     {
         return user is SocketGuildUser guildUser && guildUser.Roles.Any(x => x.Id == roleId);
     }
+    
+    public static bool IsNickAndNameEqual(this IUser user)
+    {
+        return user is SocketGuildUser guildUser && string.Equals(guildUser.Nickname, guildUser.Username, StringComparison.CurrentCultureIgnoreCase);
+    }
+    
+    // Returns a simple string formatted as: "**user.Username** (aka **user.Nickname**)"
+    // Nickname is only included if it's different from the username
+    public static string UserNameReferenceForEmbed(this IUser user)
+    {
+        var reference = $"**{user.Username}**";
+        if (!user.IsNickAndNameEqual())
+            reference += $" (aka **{user}**)";
+        return reference;
+    }
+    
+    // Returns a simple string formatted as: "user.Username (aka user.Nickname)"
+    // Nickname is only included if it's different from the username
+    public static string UserNameReference(this IUser user)
+    {
+        var reference = $"{user.Username}";
+        if (!user.IsNickAndNameEqual())
+            reference += $" (aka {user})";
+        return reference;
+    }
 }

--- a/DiscordBot/Extensions/UserExtensions.cs
+++ b/DiscordBot/Extensions/UserExtensions.cs
@@ -17,38 +17,21 @@ public static class UserExtensions
     {
         return user is SocketGuildUser guildUser && guildUser.Roles.Any(x => x.Id == roleId);
     }
+
+    // Returns the users DisplayName (nickname) if it exists, otherwise returns the username
+    public static string GetUserPreferredName(this IUser user)
+    {
+        var guildUser = user as SocketGuildUser;
+        return guildUser?.DisplayName ?? user.Username;
+    }
     
-    public static bool IsNickAndNameEqual(this IUser user)
+    public static string GetPreferredAndUsername(this IUser user)
     {
         var guildUser = user as SocketGuildUser;
         if (guildUser == null)
-            return true;
-        return string.Equals(guildUser.Nickname, guildUser.Username, StringComparison.CurrentCultureIgnoreCase);
-    }
-    
-    // Returns a simple string formatted as: "**user.Username** (aka **user.Nickname**)"
-    // Nickname is only included if it's different from the username
-    public static string UserNameReferenceForEmbed(this IUser user)
-    {
-        var reference = $"**{user.GetNickName()}**!";
-        if (!user.IsNickAndNameEqual())
-            reference += $" (aka **{user.Username}**)";
-        return reference;
-    }
-    
-    // Returns a simple string formatted as: "user.Username (aka user.Nickname)"
-    // Nickname is only included if it's different from the username
-    public static string UserNameReference(this IUser user)
-    {
-        var reference = $"{user.GetNickName()}!";
-        if (!user.IsNickAndNameEqual())
-            reference += $" (aka {user.Username})";
-        return reference;
-    }
-    
-    // Returns the nickname of the user if the IUser can be cast to it exists, otherwise returns the username
-    public static string GetNickName(this IUser user)
-    {
-        return (user as SocketGuildUser)?.Nickname ?? user.Username;
+            return user.Username;
+        if (guildUser.DisplayName == user.Username)
+            return guildUser.DisplayName;
+        return $"{guildUser.DisplayName} (aka {user.Username})";
     }
 }

--- a/DiscordBot/Extensions/UserExtensions.cs
+++ b/DiscordBot/Extensions/UserExtensions.cs
@@ -20,16 +20,19 @@ public static class UserExtensions
     
     public static bool IsNickAndNameEqual(this IUser user)
     {
-        return user is SocketGuildUser guildUser && string.Equals(guildUser.Nickname, guildUser.Username, StringComparison.CurrentCultureIgnoreCase);
+        var guildUser = user as SocketGuildUser;
+        if (guildUser == null)
+            return true;
+        return string.Equals(guildUser.Nickname, guildUser.Username, StringComparison.CurrentCultureIgnoreCase);
     }
     
     // Returns a simple string formatted as: "**user.Username** (aka **user.Nickname**)"
     // Nickname is only included if it's different from the username
     public static string UserNameReferenceForEmbed(this IUser user)
     {
-        var reference = $"**{user.Username}**";
+        var reference = $"**{user.GetNickName()}**!";
         if (!user.IsNickAndNameEqual())
-            reference += $" (aka **{user}**)";
+            reference += $" (aka **{user.Username}**)";
         return reference;
     }
     
@@ -37,9 +40,15 @@ public static class UserExtensions
     // Nickname is only included if it's different from the username
     public static string UserNameReference(this IUser user)
     {
-        var reference = $"{user.Username}";
+        var reference = $"{user.GetNickName()}!";
         if (!user.IsNickAndNameEqual())
-            reference += $" (aka {user})";
+            reference += $" (aka {user.Username})";
         return reference;
+    }
+    
+    // Returns the nickname of the user if the IUser can be cast to it exists, otherwise returns the username
+    public static string GetNickName(this IUser user)
+    {
+        return (user as SocketGuildUser)?.Nickname ?? user.Username;
     }
 }

--- a/DiscordBot/Modules/ModerationModule.cs
+++ b/DiscordBot/Modules/ModerationModule.cs
@@ -264,13 +264,8 @@ public class ModerationModule : ModuleBase
     {
         //Display rules of this channel for x seconds
         var rule = Rules.Channel.First(x => x.Id == 0);
-        IUserMessage m;
-        if (rule == null)
-            m = await ReplyAsync(
-                "There is no special rule for this channel.\nPlease follow global rules (you can get them by typing `!globalrules`)");
-        else
-            m = await ReplyAsync(
-                $"{rule.Header}{(rule.Content.Length > 0 ? rule.Content : "There is no special rule for this channel.\nPlease follow global rules (you can get them by typing `!globalrules`)")}");
+        var m = await ReplyAsync(
+            $"{rule.Header}{(rule.Content.Length > 0 ? rule.Content : "There is no special rule for this channel.\nPlease follow global rules (you can get them by typing `!globalrules`)")}");
 
         var deleteAsync = Context.Message?.DeleteAsync();
         if (deleteAsync != null) await deleteAsync;

--- a/DiscordBot/Modules/ModerationModule.cs
+++ b/DiscordBot/Modules/ModerationModule.cs
@@ -5,6 +5,8 @@ using DiscordBot.Services;
 using DiscordBot.Settings;
 using Pathoschild.NaturalTimeParser.Parser;
 using DiscordBot.Attributes;
+using DiscordBot.Utils;
+using Org.BouncyCastle.Asn1.Cms;
 
 namespace DiscordBot.Modules;
 
@@ -421,6 +423,7 @@ public class ModerationModule : ModuleBase
     }
 
     #region General Utility Commands
+    
     [Command("WelcomeMessageCount")]
     [Summary("Returns a count of pending welcome messages.")]
     [RequireModerator, HideFromHelp]
@@ -439,6 +442,41 @@ public class ModerationModule : ModuleBase
             await ReplyAsync("There are no pending welcome messages.").DeleteAfterSeconds(seconds: 10);
         }
         await Context.Message.DeleteAsync();
+    }
+    
+    // Command to show the tags available for a specific channel, so the command needs to be run in a channel with tags or specific a channel id to check
+    [Command("ChannelTags")]
+    [Summary("Returns a list of tags for the current channel.")]
+    [RequireModerator, HideFromHelp]
+    public async Task ChannelTags(ulong channelId)
+    {
+        // Get the channel
+        var channel = await Context.Guild.GetChannelAsync(channelId);
+
+        if (channel is not IForumChannel forumChannel)
+        {
+            await ReplyAsync($"<#{channelId}> is not a forum channel and has no tags.").DeleteAfterSeconds(seconds: 10);
+            return;
+        }
+
+        var tags = forumChannel.Tags;
+        // If there are no tags, say so
+        if (tags.Count == 0)
+        {
+            await ReplyAsync($"<#{channelId}> has no tags.").DeleteAfterSeconds(seconds: 10);
+            return;
+        }
+
+        // If there are tags, list them in an embed in format of (ID: `id` - Name: `name`)
+        var embed = new EmbedBuilder()
+            .WithTitle($"Tags for <#{channelId}>")
+            .WithDescription(string.Join("\n", tags.Select(tag => $"ID: `{tag.Id}` - Name: `{tag.Name}`")) +
+                             $"\n\n{StringUtil.MessageSelfDestructIn(60)}")
+            .WithColor(Color.Blue)
+            .Build();
+
+        Context.Message.DeleteAsync();
+        await ReplyAsync(embed: embed).DeleteAfterSeconds(seconds: 60);
     }
 
     #endregion

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -131,7 +131,7 @@ public class UserModule : ModuleBase
             .WithFooter(footer =>
             {
                 footer
-                    .WithText($"Quoted by {Context.User.Username}#{Context.User.Discriminator} • From channel {message.Channel.Name}")
+                    .WithText($"Quoted by {Context.User.UserNameReference()} • From channel {message.Channel.Name}")
                     .WithIconUrl(Context.User.GetAvatarUrl());
             })
             .WithAuthor(author =>

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -131,7 +131,7 @@ public class UserModule : ModuleBase
             .WithFooter(footer =>
             {
                 footer
-                    .WithText($"Quoted by {Context.User.UserNameReference()} • From channel {message.Channel.Name}")
+                    .WithText($"Quoted by {Context.User.GetUserPreferredName()} • From channel {message.Channel.Name}")
                     .WithIconUrl(Context.User.GetAvatarUrl());
             })
             .WithAuthor(author =>

--- a/DiscordBot/Modules/UserSlashModule.cs
+++ b/DiscordBot/Modules/UserSlashModule.cs
@@ -170,7 +170,7 @@ public class UserSlashModule : InteractionModuleBase
         .WithFooter(footer =>
         {
             footer
-                .WithText($"Reported by {Context.User.UserNameReference()} • From channel {reportedMessage.Channel.Name}")
+                .WithText($"Reported by {Context.User.GetPreferredAndUsername()} • From channel {reportedMessage.Channel.Name}")
                 .WithIconUrl(Context.User.GetAvatarUrl());
         })
         .WithAuthor(author =>

--- a/DiscordBot/Modules/UserSlashModule.cs
+++ b/DiscordBot/Modules/UserSlashModule.cs
@@ -170,7 +170,7 @@ public class UserSlashModule : InteractionModuleBase
         .WithFooter(footer =>
         {
             footer
-                .WithText($"Reported by {Context.User.Username}#{Context.User.Discriminator} • From channel {reportedMessage.Channel.Name}")
+                .WithText($"Reported by {Context.User.UserNameReference()} • From channel {reportedMessage.Channel.Name}")
                 .WithIconUrl(Context.User.GetAvatarUrl());
         })
         .WithAuthor(author =>

--- a/DiscordBot/Program.cs
+++ b/DiscordBot/Program.cs
@@ -68,6 +68,7 @@ public class Program
                 _isInitialized = true;
                 
                 _unityHelpService = _services.GetRequiredService<UnityHelpService>();
+                _services.GetRequiredService<RecruitService>();
             }
             return Task.CompletedTask;
         };
@@ -91,6 +92,7 @@ public class Program
             .AddSingleton<PublisherService>()
             .AddSingleton<FeedService>()
             .AddSingleton<UnityHelpService>()
+            .AddSingleton<RecruitService>()
             .AddSingleton<UpdateService>()
             .AddSingleton<CurrencyService>()
             .AddSingleton<ReactRoleService>()

--- a/DiscordBot/Program.cs
+++ b/DiscordBot/Program.cs
@@ -64,7 +64,7 @@ public class Program
                     ?.GetTextChannel(_settings.BotAnnouncementChannel.Id)
                     ?.SendMessageAsync("Bot Started.");
 
-                LoggingService.LogToConsole("Bot is connected.", LogSeverity.Info);
+                LoggingService.LogToConsole("Bot is connected.", ExtendedLogSeverity.Positive);
                 _isInitialized = true;
                 
                 _unityHelpService = _services.GetRequiredService<UnityHelpService>();

--- a/DiscordBot/Services/DatabaseService.cs
+++ b/DiscordBot/Services/DatabaseService.cs
@@ -9,7 +9,7 @@ namespace DiscordBot.Services;
 
 public class DatabaseService
 {
-    private static readonly string ServiceName = "DatabaseService"; 
+    private const string ServiceName = "DatabaseService"; 
     
     private readonly ILoggingService _logging;
     private string ConnectionString { get; }
@@ -44,7 +44,7 @@ public class DatabaseService
                 await _logging.LogAction($"{ServiceName}: Connected to database successfully. {userCount} users in database.");
                 LoggingService.LogToConsole($"{ServiceName}: Connected to database successfully. {userCount} users in database.", ExtendedLogSeverity.Positive);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 LoggingService.LogToConsole(
                     "DatabaseService: Table 'users' does not exist, attempting to generate table.",

--- a/DiscordBot/Services/DatabaseService.cs
+++ b/DiscordBot/Services/DatabaseService.cs
@@ -134,7 +134,7 @@ public class DatabaseService
             await Query().InsertUser(user);
 
             await _logging.LogAction(
-                $"User {socketUser.Username}#{socketUser.DiscriminatorValue.ToString()} successfully added to the database.",
+                $"User {socketUser.UserNameReference()} successfully added to the database.",
                 true,
                 false);
         }

--- a/DiscordBot/Services/DatabaseService.cs
+++ b/DiscordBot/Services/DatabaseService.cs
@@ -46,11 +46,23 @@ public class DatabaseService
                 LoggingService.LogToConsole(
                     "DatabaseService: Table 'users' does not exist, attempting to generate table.",
                     LogSeverity.Warning);
-                c.ExecuteSql(
-                    "CREATE TABLE `users` (`ID` int(11) UNSIGNED  NOT NULL, `UserID` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL, `Karma` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaWeekly` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaMonthly` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaYearly` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaGiven` int(11) UNSIGNED NOT NULL DEFAULT 0, `Exp` bigint(11) UNSIGNED  NOT NULL DEFAULT 0, `Level` int(11) UNSIGNED NOT NULL DEFAULT 0) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
-                c.ExecuteSql("ALTER TABLE `users` ADD PRIMARY KEY (`ID`,`UserID`), ADD UNIQUE KEY `UserID` (`UserID`)");
-                c.ExecuteSql(
-                    "ALTER TABLE `users` MODIFY `ID` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=1");
+                try
+                {
+                    c.ExecuteSql(
+                        "CREATE TABLE `users` (`ID` int(11) UNSIGNED  NOT NULL, `UserID` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL, `Karma` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaWeekly` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaMonthly` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaYearly` int(11) UNSIGNED  NOT NULL DEFAULT 0, `KarmaGiven` int(11) UNSIGNED NOT NULL DEFAULT 0, `Exp` bigint(11) UNSIGNED  NOT NULL DEFAULT 0, `Level` int(11) UNSIGNED NOT NULL DEFAULT 0) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+                    c.ExecuteSql(
+                        "ALTER TABLE `users` ADD PRIMARY KEY (`ID`,`UserID`), ADD UNIQUE KEY `UserID` (`UserID`)");
+                    c.ExecuteSql(
+                        "ALTER TABLE `users` MODIFY `ID` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=1");
+                }
+                catch (Exception e)
+                {
+                    LoggingService.LogToConsole(
+                        $"SQL Exception: Failed to generate table 'users'.\nMessage: {e}",
+                        LogSeverity.Critical);
+                    c.Close();
+                    return;
+                }
                 LoggingService.LogToConsole("DatabaseService: Table 'users' generated without errors.",
                     LogSeverity.Info);
                 c.Close();

--- a/DiscordBot/Services/DatabaseService.cs
+++ b/DiscordBot/Services/DatabaseService.cs
@@ -9,6 +9,8 @@ namespace DiscordBot.Services;
 
 public class DatabaseService
 {
+    private static readonly string ServiceName = "DatabaseService"; 
+    
     private readonly ILoggingService _logging;
     private string ConnectionString { get; }
 
@@ -39,13 +41,14 @@ public class DatabaseService
             try
             {
                 var userCount = await _connection.TestConnection();
-                await _logging.LogAction($"DatabaseService: Connected to database successfully. {userCount} users in database.");
+                await _logging.LogAction($"{ServiceName}: Connected to database successfully. {userCount} users in database.");
+                LoggingService.LogToConsole($"{ServiceName}: Connected to database successfully. {userCount} users in database.", ExtendedLogSeverity.Positive);
             }
             catch (Exception)
             {
                 LoggingService.LogToConsole(
                     "DatabaseService: Table 'users' does not exist, attempting to generate table.",
-                    LogSeverity.Warning);
+                    ExtendedLogSeverity.LowWarning);
                 try
                 {
                     c.ExecuteSql(
@@ -64,7 +67,7 @@ public class DatabaseService
                     return;
                 }
                 LoggingService.LogToConsole("DatabaseService: Table 'users' generated without errors.",
-                    LogSeverity.Info);
+                    ExtendedLogSeverity.Positive);
                 c.Close();
             }
 

--- a/DiscordBot/Services/DatabaseService.cs
+++ b/DiscordBot/Services/DatabaseService.cs
@@ -44,7 +44,7 @@ public class DatabaseService
                 await _logging.LogAction($"{ServiceName}: Connected to database successfully. {userCount} users in database.");
                 LoggingService.LogToConsole($"{ServiceName}: Connected to database successfully. {userCount} users in database.", ExtendedLogSeverity.Positive);
             }
-            catch (Exception ex)
+            catch
             {
                 LoggingService.LogToConsole(
                     "DatabaseService: Table 'users' does not exist, attempting to generate table.",

--- a/DiscordBot/Services/DatabaseService.cs
+++ b/DiscordBot/Services/DatabaseService.cs
@@ -146,7 +146,7 @@ public class DatabaseService
             await Query().InsertUser(user);
 
             await _logging.LogAction(
-                $"User {socketUser.UserNameReference()} successfully added to the database.",
+                $"User {socketUser.GetPreferredAndUsername()} successfully added to the database.",
                 true,
                 false);
         }

--- a/DiscordBot/Services/LoggingService.cs
+++ b/DiscordBot/Services/LoggingService.cs
@@ -63,6 +63,16 @@ public class LoggingService : ILoggingService
         Console.ForegroundColor = restoreColour;
     }
     
+    public static void LogServiceDisabled(string service, string varName)
+    {
+        LogToConsole($"Service \"{service}\" is Disabled, {varName} is false in settings.json", LogSeverity.Warning);
+    }
+    
+    public static void LogServiceEnabled(string service)
+    {
+        LogToConsole($"Service \"{service}\" is Enabled", LogSeverity.Info);
+    }
+
     /// <summary>
     /// Same behaviour as LogToConsole, however this method is not included in the release build.
     /// Good if you need more verbose but obvious logging, but don't want it included in release.

--- a/DiscordBot/Services/LoggingService.cs
+++ b/DiscordBot/Services/LoggingService.cs
@@ -89,6 +89,7 @@ public class LoggingService : ILoggingService
                 break;
             case LogSeverity.Verbose:
             case LogSeverity.Debug:
+            default:
                 Console.ForegroundColor = ConsoleColor.DarkGray;
                 break;
         }

--- a/DiscordBot/Services/LoggingService.cs
+++ b/DiscordBot/Services/LoggingService.cs
@@ -144,15 +144,15 @@ public class LoggingService : ILoggingService
             case ExtendedLogSeverity.LowWarning:
                 Console.ForegroundColor = ConsoleColor.DarkYellow;
                 break;
-            case ExtendedLogSeverity.Verbose:
-            case ExtendedLogSeverity.Debug:
+            // case ExtendedLogSeverity.Verbose:
+            // case ExtendedLogSeverity.Debug:
             default:
                 Console.ForegroundColor = ConsoleColor.DarkGray;
                 break;
         }
     }
     #endregion
-}
+} 
 
 public interface ILoggingService
 {

--- a/DiscordBot/Services/ModerationService.cs
+++ b/DiscordBot/Services/ModerationService.cs
@@ -7,6 +7,10 @@ public class ModerationService
 {
     private readonly ILoggingService _loggingService;
     private readonly BotSettings _settings;
+    
+    private static readonly int MaxMessageLength = 800;
+    private static readonly Color DeletedMessageColor = new Color(200, 128, 128);
+    private static readonly Color EditedMessageColor = new Color(255, 255, 128);
 
     public ModerationService(DiscordSocketClient client, BotSettings settings, ILoggingService loggingService)
     {
@@ -14,6 +18,7 @@ public class ModerationService
         _loggingService = loggingService;
 
         client.MessageDeleted += MessageDeleted;
+        client.MessageUpdated += MessageUpdated;
     }
 
     private async Task MessageDeleted(Cacheable<IMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel)
@@ -22,12 +27,12 @@ public class ModerationService
             return;
 
         var content = message.Value.Content;
-        if (content.Length > 800)
-            content = content.Substring(0, 800);
+        if (content.Length > MaxMessageLength)
+            content = content[..MaxMessageLength];
 
         var user = message.Value.Author;
         var builder = new EmbedBuilder()
-            .WithColor(new Color(200, 128, 128))
+            .WithColor(DeletedMessageColor)
             .WithTimestamp(message.Value.Timestamp)
             .WithFooter(footer =>
             {
@@ -37,14 +42,64 @@ public class ModerationService
             .WithAuthor(author =>
             {
                 author
-                    .WithName($"{user.Username}");
+                    .WithName($"{user.GetPreferredAndUsername()} deleted a message");
             })
-            .AddField("Deleted message", content);
+            .AddField($"Deleted Message {(content.Length != message.Value.Content.Length ? "(truncated)" : "")}",
+                content);
         var embed = builder.Build();
+
+        // TimeStamp for the Footer
+
+        await _loggingService.LogAction(
+            $"User {user.GetPreferredAndUsername()} has " +
+            $"deleted the message\n{content}\n from channel #{(await channel.GetOrDownloadAsync()).Name}", true, false);
+        await _loggingService.LogAction(" ", false, true, embed);
+    }
+
+    private async Task MessageUpdated(Cacheable<IMessage, ulong> before, SocketMessage after, ISocketMessageChannel channel)
+    {
+        if (after.Author.IsBot || channel.Id == _settings.BotAnnouncementChannel.Id)
+            return;
+
+        bool isCached = true;
+        string content = "";
+        var beforeMessage = await before.GetOrDownloadAsync();
+        if (beforeMessage == null || beforeMessage.Content == after.Content)
+            isCached = false;
+        else
+            content = beforeMessage.Content;
+
+        bool isTruncated = false;
+        if (content.Length > MaxMessageLength)
+        {
+            content = content[..MaxMessageLength];
+            isTruncated = true;
+        }
+
+        var user = after.Author;
+        var builder = new EmbedBuilder()
+            .WithColor(EditedMessageColor)
+            .WithTimestamp(after.Timestamp)
+            .WithFooter(footer =>
+            {
+                footer
+                    .WithText($"In channel {after.Channel.Name}");
+            })
+            .WithAuthor(author =>
+            {
+                author
+                    .WithName($"{user.GetPreferredAndUsername()} updated a message");
+            });
+        if (isCached)
+            builder.AddField($"Message Content {(isTruncated ? "(truncated)" : "")}", content);
+        builder.WithDescription($"Message: [{after.Id}]({after.GetJumpUrl()})");
+            var embed = builder.Build();
+        
+        // TimeStamp for the Footer
         
         await _loggingService.LogAction(
-            $"User {user.UserNameReference()} has " +
-            $"deleted the message\n{content}\n from channel #{(await channel.GetOrDownloadAsync()).Name}", true, false);
+            $"User {user.GetPreferredAndUsername()} has " +
+            $"updated the message\n{content}\n in channel #{channel.Name}", true, false);
         await _loggingService.LogAction(" ", false, true, embed);
     }
 }

--- a/DiscordBot/Services/ModerationService.cs
+++ b/DiscordBot/Services/ModerationService.cs
@@ -25,6 +25,7 @@ public class ModerationService
         if (content.Length > 800)
             content = content.Substring(0, 800);
 
+        var user = message.Value.Author;
         var builder = new EmbedBuilder()
             .WithColor(new Color(200, 128, 128))
             .WithTimestamp(message.Value.Timestamp)
@@ -36,13 +37,13 @@ public class ModerationService
             .WithAuthor(author =>
             {
                 author
-                    .WithName($"{message.Value.Author.Username}");
+                    .WithName($"{user.Username}");
             })
             .AddField("Deleted message", content);
         var embed = builder.Build();
-
+        
         await _loggingService.LogAction(
-            $"User {message.Value.Author.Username}#{message.Value.Author.DiscriminatorValue} has " +
+            $"User {user.UserNameReference()} has " +
             $"deleted the message\n{content}\n from channel #{(await channel.GetOrDownloadAsync()).Name}", true, false);
         await _loggingService.LogAction(" ", false, true, embed);
     }

--- a/DiscordBot/Services/ModerationService.cs
+++ b/DiscordBot/Services/ModerationService.cs
@@ -8,9 +8,9 @@ public class ModerationService
     private readonly ILoggingService _loggingService;
     private readonly BotSettings _settings;
     
-    private static readonly int MaxMessageLength = 800;
-    private static readonly Color DeletedMessageColor = new Color(200, 128, 128);
-    private static readonly Color EditedMessageColor = new Color(255, 255, 128);
+    private const int MaxMessageLength = 800;
+    private static readonly Color DeletedMessageColor = new (200, 128, 128);
+    private static readonly Color EditedMessageColor = new (255, 255, 128);
 
     public ModerationService(DiscordSocketClient client, BotSettings settings, ILoggingService loggingService)
     {

--- a/DiscordBot/Services/ModerationService.cs
+++ b/DiscordBot/Services/ModerationService.cs
@@ -91,7 +91,7 @@ public class ModerationService
                     .WithName($"{user.GetPreferredAndUsername()} updated a message");
             });
         if (isCached)
-            builder.AddField($"Message Content {(isTruncated ? "(truncated)" : "")}", content);
+            builder.AddField($"Previous message content {(isTruncated ? "(truncated)" : "")}", content);
         builder.WithDescription($"Message: [{after.Id}]({after.GetJumpUrl()})");
             var embed = builder.Build();
         

--- a/DiscordBot/Services/ReactRoleService.cs
+++ b/DiscordBot/Services/ReactRoleService.cs
@@ -33,6 +33,10 @@ public class ReactRoleService
         _settings = settings;
 
         _client = client;
+
+        if (!_settings.ReactRoleServiceEnabled)
+            return;
+        
         _client.ReactionAdded += ReactionAdded;
         _client.ReactionRemoved += ReactionRemoved;
         

--- a/DiscordBot/Services/Recruitment/RecruitService.cs
+++ b/DiscordBot/Services/Recruitment/RecruitService.cs
@@ -35,7 +35,7 @@ public class RecruitService
     private const int MinimumLengthMessage = 120;
     private const int ShortMessageNoticeDurationInSec = 30 * 4;
 
-    private int _editTimePermissionInMin = 30;
+    private readonly int _editTimePermissionInMin;
     private const string _messageToBeEdited = "This post will remain editable until %s, make any desired changes to your thread. After that the thread will be locked.";
 
 

--- a/DiscordBot/Services/Recruitment/RecruitService.cs
+++ b/DiscordBot/Services/Recruitment/RecruitService.cs
@@ -1,0 +1,305 @@
+using Discord.WebSocket;
+using DiscordBot.Services.UnityHelp;
+using DiscordBot.Settings;
+using DiscordBot.Utils;
+
+public class RecruitService
+{
+    private static readonly string ServiceName = "RecruitmentService";
+    
+    private readonly DiscordSocketClient _client;
+    private readonly ILoggingService _logging;
+    private SocketRole ModeratorRole { get; set; }
+
+    #region Extra Details
+    
+    private readonly ForumTag _tagIsHiring;
+    private readonly ForumTag _tagWantsWork;
+    private readonly ForumTag _tagUnpaidCollab;
+    private readonly ForumTag _tagPosFilled;
+
+    private readonly IForumChannel _recruitChannel;
+
+    #endregion // Extra Details
+    
+    #region Configuration
+
+    private Color DeletedMessageColor => new Color(255, 50, 50);
+    private Color WarningMessageColor => new Color(255, 255, 100);
+
+    private const int TimeBeforeDeletingForumInSec = 30;
+    private const int MinimumLengthMessage = 120;
+
+    private string _messageToBeDeleted =
+        "Your thread will be deleted in %s because it did not follow the expected guidelines. Try again after the slow mode period has passed.";
+    private Embed _userHiringButNoPrice;
+    private Embed _userWantsWorkButNoPrice;
+
+    private Embed _userDidntUseTags;
+    private Embed _userRevShareMentioned;
+    private Embed _userMoreThanOneTagUsed;
+    private Embed _userShortMessage;
+    
+    Dictionary<ulong, bool> _botSanityCheck = new Dictionary<ulong, bool>();
+
+    #endregion // Configuration
+    
+    public RecruitService(DiscordSocketClient client, ILoggingService logging, BotSettings settings)
+    {
+        _client = client;
+        _logging = logging;
+        ModeratorRole = _client.GetGuild(settings.GuildId).GetRole(settings.ModeratorRoleId);
+
+        if (!settings.RecruitmentServiceEnabled)
+        {
+            LoggingService.LogServiceDisabled(ServiceName, nameof(settings.RecruitmentServiceEnabled));
+            return;
+        }
+        
+        // Get target channel
+        _recruitChannel = _client.GetChannel(settings.RecruitmentChannel.Id) as IForumChannel;
+        if (_recruitChannel == null)
+        {
+            LoggingService.LogToConsole("[{ServiceName}] Recruitment channel not found.", LogSeverity.Error);
+            return;
+        }
+        
+        try
+        {
+            var lookingToHire = ulong.Parse(settings.TagLookingToHire);
+            var lookingForWork = ulong.Parse(settings.TagLookingForWork);
+            var unpaidCollab = ulong.Parse(settings.TagUnpaidCollab);
+            var positionFilled = ulong.Parse(settings.TagPositionFilled);
+            
+            var availableTags = _recruitChannel.Tags;
+            _tagIsHiring = availableTags.First(x => x.Id == lookingToHire);
+            _tagWantsWork = availableTags.First(x => x.Id == lookingForWork);
+            _tagUnpaidCollab = availableTags.First(x => x.Id == unpaidCollab);
+            _tagPosFilled = availableTags.First(x => x.Id == positionFilled);
+            
+            // If any tags are null we print a logging warning
+            if (_tagIsHiring == null) StartUpTagMissing(lookingToHire, nameof(settings.TagLookingToHire));
+            if (_tagWantsWork == null) StartUpTagMissing(lookingForWork, nameof(settings.TagLookingForWork));
+            if (_tagUnpaidCollab == null) StartUpTagMissing(unpaidCollab, nameof(settings.TagUnpaidCollab));
+            if (_tagPosFilled == null) StartUpTagMissing(positionFilled, nameof(settings.TagPositionFilled));
+        }
+        catch (Exception e)
+        {
+            LoggingService.LogToConsole($"[{ServiceName}] Error parsing recruitment tags: {e.Message}", LogSeverity.Error);
+        }
+
+        // Subscribe to events
+        _client.ThreadCreated += GatewayOnThreadCreated;
+
+        ConstructEmbeds();
+        
+        LoggingService.LogServiceEnabled(ServiceName);
+    }
+    
+    #region Thread Creation
+
+    private async Task GatewayOnThreadCreated(SocketThreadChannel thread)
+    {
+        if (!thread.IsThreadInChannel(_recruitChannel.Id))
+            return;
+        if (thread.Owner.IsUserBotOrWebhook())
+            return;
+        if (thread.Owner.HasRoleGroup(ModeratorRole))
+            return;
+
+        #region Sanity Check
+        // Oddly the thread is sometimes called twice, so we do a sanity check to make sure we don't process it twice.
+        // Probably a better way to do this, but this is pretty cheap operation.
+        if (_botSanityCheck.ContainsKey(thread.Id))
+        {
+            _botSanityCheck.Remove(thread.Id);
+            return;
+        }
+        if (_botSanityCheck.Count > 10)
+            _botSanityCheck.Clear();
+        _botSanityCheck.Add(thread.Id, true);
+        #endregion // Sanity Check
+        
+        LoggingService.DebugLog($"[{ServiceName}] New Thread Created: {thread.Id} - {thread.Name}", LogSeverity.Debug);
+
+        var message = (await thread.GetMessagesAsync(1).FlattenAsync()).FirstOrDefault();
+        if (message == null)
+        {
+            LoggingService.LogToConsole($"[{ServiceName}] Thread {thread.Id} has no messages.", LogSeverity.Error);
+            return;
+        }
+
+        Task.Run(async () =>
+        {
+            if (thread.AppliedTags.Count == 0)
+            {
+                await ThreadHandleNoTags(thread, message);
+                return;
+            }
+
+            if (IsThreadUsingMoreThanOneTag(thread))
+            {
+                await ThreadHandleMoreThanOneTag(thread, message);
+                return;
+            }
+
+            bool isPaidWork = (thread.AppliedTags.Contains(_tagWantsWork.Id) ||
+                               thread.AppliedTags.Contains(_tagIsHiring.Id));
+
+            if (isPaidWork)
+            {
+                if (!message.Content.ContainsCurrencySymbol())
+                {
+                    await ThreadHandleExpectedCurrency(thread, message);
+                    return;
+                }
+                await ThreadHandleRevShare(thread, message);
+            }
+            
+            await ThreadHandleShortMessage(thread, message);
+        });
+    }
+
+    #endregion // Thread Creation
+
+    #region Basic Handlers for posts
+
+    private async Task ThreadHandleExpectedCurrency(SocketThreadChannel thread, IMessage message)
+    {
+        var embedToUse = thread.AppliedTags.Contains(_tagWantsWork.Id)
+            ? _userWantsWorkButNoPrice
+            : _userHiringButNoPrice;
+        await thread.SendMessageAsync(embed: embedToUse);
+        await DeleteThread(thread);
+    }
+
+    private async Task ThreadHandleRevShare(SocketThreadChannel thread, IMessage message)
+    {
+        if (message.Content.ContainsRevShare())
+        {
+            await thread.SendMessageAsync(embed: _userRevShareMentioned);
+        }
+    }
+    
+    private async Task ThreadHandleMoreThanOneTag(SocketThreadChannel thread, IMessage message)
+    {
+        await thread.SendMessageAsync(embed: _userMoreThanOneTagUsed);
+        await DeleteThread(thread);
+    }
+    
+    private async Task ThreadHandleNoTags(SocketThreadChannel thread, IMessage message)
+    {
+        await thread.SendMessageAsync(embed: _userDidntUseTags);
+        await DeleteThread(thread);
+    }
+    
+    private async Task ThreadHandleShortMessage(SocketThreadChannel thread, IMessage message)
+    {
+        if (message.Content.Length < MinimumLengthMessage)
+        {
+            var ourResponse = await thread.SendMessageAsync(embed: _userShortMessage);
+            await ourResponse.DeleteAfterSeconds(TimeBeforeDeletingForumInSec * 5);
+        }
+    }
+    
+    #endregion // Basic Handlers for posts
+
+    #region Basic Logging Assisst
+
+    private static void StartUpTagMissing(ulong tagId, string tagName)
+    {
+        LoggingService.LogToConsole($"[{ServiceName}] Tag {tagId} not found. '{tagName}'", LogSeverity.Error);
+    }
+
+    #endregion // Basic Logging Assisst
+
+    #region Embed Construction
+
+    private void ConstructEmbeds()
+    {
+        _userHiringButNoPrice = new EmbedBuilder()
+            .WithTitle($"No payment price detected")
+            .WithDescription(
+                $"You have used the `{_tagIsHiring.Name}` tag but have not specified a price of any kind.\n\nPost **must** include a currency symbol or word, e.g. $, dollars, USD, £, pounds, €, EUR, euro, euros, GBP.")
+            .WithColor(DeletedMessageColor)
+            .Build();
+        
+        _userWantsWorkButNoPrice = new EmbedBuilder()
+            .WithTitle($"No payment price detected")
+            .WithDescription(
+                $"You have used the `{_tagWantsWork.Name}` tag but have not specified a price of any kind.\n\nPost **must** include a currency symbol or word, e.g. $, dollars, USD, £, pounds, €, EUR, euro, euros, GBP.")
+            .WithColor(DeletedMessageColor)
+            .Build();
+        
+        _userRevShareMentioned = new EmbedBuilder()
+            .WithTitle($"Notice: Rev-Share mentioned")
+            .WithDescription(
+                $"Rev-share isn't considered a valid form of payment for `{_tagIsHiring.Name}` or `{_tagWantsWork.Name}` as it's not guaranteed. " +
+                $"Consider using the `{_tagUnpaidCollab.Name}` tag instead if you intend to use rev-share as a source of payment.")
+            .WithColor(WarningMessageColor)
+            .Build();
+        
+        _userMoreThanOneTagUsed = new EmbedBuilder()
+            .WithTitle($"Broken Guideline: Colliding tags used")
+            .WithDescription(
+                $"You may only use one of the following tags: `{_tagIsHiring.Name}`, `{_tagWantsWork.Name}` or `{_tagUnpaidCollab.Name}`\n\n" +
+                $"Be sure to read the guidelines before posting.")
+            .WithColor(DeletedMessageColor)
+            .Build();
+        
+        _userDidntUseTags = new EmbedBuilder()
+            .WithTitle($"Broken Guideline: No tags used")
+            .WithDescription(
+                $"You must use one of the following tags: `{_tagIsHiring.Name}`, `{_tagWantsWork.Name}` or `{_tagUnpaidCollab.Name}`\n\n" +
+                $"Be sure to read the guidelines before posting.")
+            .WithColor(DeletedMessageColor)
+            .Build();
+        
+        _userShortMessage = new EmbedBuilder()
+            .WithTitle($"Warning: Post is short")
+            .WithDescription(
+                $"Your post should contain enough information to convince others to work with you, we recommend at least {MinimumLengthMessage} characters, " +
+                $"which is still very short.\n\nPlease edit your post to contain more information otherwise it may be deleted by staff.")
+            .WithColor(WarningMessageColor)
+            .Build();
+    }
+    
+    private Embed GetDeletedMessageEmbed()
+    {
+        // Create a dynamic timestamp for now + TimeBeforeDeletingForumInSec
+        var timestamp = DateTimeOffset.Now.AddSeconds(TimeBeforeDeletingForumInSec);
+        var timestampString = $"<t:{timestamp.ToUnixTimeSeconds()}:R>";
+        var message = _messageToBeDeleted.Replace("%s", timestampString);
+        
+        return new EmbedBuilder()
+            .WithTitle($"Post does not follow guidelines")
+            .WithDescription(message)
+            .WithColor(DeletedMessageColor)
+            .Build();
+    }
+
+    #endregion // Embed Construction
+
+    #region Basic Utility
+
+    private bool IsThreadUsingMoreThanOneTag(SocketThreadChannel thread)
+    {
+        int clashingTagCount = 0;
+        var tags = thread.AppliedTags;
+        
+        if (tags.Contains(_tagIsHiring.Id)) clashingTagCount++;
+        if (tags.Contains(_tagWantsWork.Id)) clashingTagCount++;
+        if (tags.Contains(_tagUnpaidCollab.Id)) clashingTagCount++;
+        
+        return clashingTagCount > 1;
+    }
+    
+    private async Task DeleteThread(SocketThreadChannel thread)
+    {
+        await thread.SendMessageAsync(embed: GetDeletedMessageEmbed());
+        await thread.DeleteAfterSeconds(TimeBeforeDeletingForumInSec);
+    }
+
+    #endregion // Basic Utility
+    
+}

--- a/DiscordBot/Services/Recruitment/RecruitService.cs
+++ b/DiscordBot/Services/Recruitment/RecruitService.cs
@@ -6,7 +6,7 @@ namespace DiscordBot.Services;
 
 public class RecruitService
 {
-    private static readonly string ServiceName = "RecruitmentService";
+    private const string ServiceName = "RecruitmentService";
     
     private readonly DiscordSocketClient _client;
     private readonly ILoggingService _logging;
@@ -185,12 +185,9 @@ public class RecruitService
                 return;
             
             // We do one last check to make sure the thread is still valid
-            if (isPaidWork)
+            if (isPaidWork && !threadMessage.Content.ContainsCurrencySymbol())
             {
-                if (!threadMessage.Content.ContainsCurrencySymbol())
-                {
-                    await ThreadHandleExpectedCurrency(channel);
-                }
+                await ThreadHandleExpectedCurrency(channel);
             }
         });
     }

--- a/DiscordBot/Services/UnityHelp/UnityHelpService.cs
+++ b/DiscordBot/Services/UnityHelp/UnityHelpService.cs
@@ -8,7 +8,7 @@ namespace DiscordBot.Services;
 
 public class UnityHelpService
 {
-    private static readonly string ServiceName = "UnityHelpService";
+    private const string ServiceName = "UnityHelpService";
 
     private readonly DiscordSocketClient _client;
     private readonly ILoggingService _logging;

--- a/DiscordBot/Services/UnityHelp/UnityHelpService.cs
+++ b/DiscordBot/Services/UnityHelp/UnityHelpService.cs
@@ -8,6 +8,8 @@ namespace DiscordBot.Services;
 
 public class UnityHelpService
 {
+    private static readonly string ServiceName = "UnityHelpService";
+
     private readonly DiscordSocketClient _client;
     private readonly ILoggingService _logging;
     private SocketRole ModeratorRole { get; set; }
@@ -83,6 +85,12 @@ public class UnityHelpService
         
         ModeratorRole = _client.GetGuild(settings.GuildId).GetRole(settings.ModeratorRoleId);
 
+        if (!settings.UnityHelpBabySitterEnabled)
+        {
+            LoggingService.LogServiceDisabled(ServiceName, nameof(settings.UnityHelpBabySitterEnabled));
+            return;
+        }
+        
         // get the help channel settings.GenericHelpChannel
         _helpChannel = _client.GetChannel(settings.GenericHelpChannel.Id) as IForumChannel;
         if (_helpChannel == null)
@@ -106,6 +114,8 @@ public class UnityHelpService
         _client.MessageUpdated += GatewayOnMessageUpdated;
 
         Task.Run(LoadActiveThreads);
+        
+        LoggingService.LogServiceEnabled(ServiceName);
     }
 
     private async Task LoadActiveThreads()

--- a/DiscordBot/Services/UnityHelp/UnityHelpService.cs
+++ b/DiscordBot/Services/UnityHelp/UnityHelpService.cs
@@ -95,7 +95,7 @@ public class UnityHelpService
         _helpChannel = _client.GetChannel(settings.GenericHelpChannel.Id) as IForumChannel;
         if (_helpChannel == null)
         {
-            LoggingService.LogToConsole("[UnityHelpService] Help channel not found", LogSeverity.Error);
+            LoggingService.LogToConsole($"[{ServiceName}] Help channel not found", LogSeverity.Error);
         }
         var resolvedTag = _helpChannel!.Tags.FirstOrDefault(x => x.Name == ResolvedTag);
         _resolvedForumTag = resolvedTag;
@@ -217,7 +217,7 @@ public class UnityHelpService
         if (_activeThreads.ContainsKey(thread.Id))
             return Task.CompletedTask;
         
-        LoggingService.DebugLog($"[UnityHelpService] New Thread Created: {thread.Id} - {thread.Name}", LogSeverity.Debug);
+        LoggingService.DebugLog($"[{ServiceName}] New Thread Created: {thread.Id} - {thread.Name}", LogSeverity.Debug);
         Task.Run(() => OnThreadCreated(thread));
         
         return Task.CompletedTask;
@@ -291,7 +291,7 @@ public class UnityHelpService
             return;
         }
 
-        LoggingService.DebugLog($"[UnityHelpService] Thread Updated: {after.Id} - {after.Name}", LogSeverity.Debug);
+        LoggingService.DebugLog($"[{ServiceName}] Thread Updated: {after.Id} - {after.Name}", LogSeverity.Debug);
         
 #pragma warning disable CS4014
         Task.Run(() => OnThreadUpdated(beforeThread, afterThread));
@@ -312,7 +312,7 @@ public class UnityHelpService
         if (!_activeThreads.ContainsKey(threadId.Id))
             return;
         
-        LoggingService.DebugLog($"[UnityHelpService] Thread Deleted: {threadId.Id}", LogSeverity.Debug);
+        LoggingService.DebugLog($"[{ServiceName}] Thread Deleted: {threadId.Id}", LogSeverity.Debug);
         var thread = await threadId.GetOrDownloadAsync();
 
 #pragma warning disable CS4014
@@ -388,7 +388,7 @@ public class UnityHelpService
         if (!_activeThreads.TryGetValue(message.Channel.Id, out var thread))
             return Task.CompletedTask;
         
-        LoggingService.DebugLog($"[UnityHelpService] Help Message Received: {message.Id} - {message.Content}", LogSeverity.Debug);
+        LoggingService.DebugLog($"[{ServiceName}] Help Message Received: {message.Id} - {message.Content}", LogSeverity.Debug);
         Task.Run(() => OnMessageReceived(message));
         return Task.CompletedTask;
     }
@@ -429,7 +429,7 @@ public class UnityHelpService
         if (beforeMsg == null)
             return;
 
-        LoggingService.DebugLog($"[UnityHelpService] Help Message Updated: {after.Id} - {after.Content}", LogSeverity.Debug);
+        LoggingService.DebugLog($"[{ServiceName}] Help Message Updated: {after.Id} - {after.Content}", LogSeverity.Debug);
 #pragma warning disable CS4014
         Task.Run(() => OnMessageUpdated(beforeMsg, after, channel as SocketThreadChannel));
 #pragma warning restore CS4014
@@ -718,7 +718,7 @@ public class UnityHelpService
             return Task.FromResult(false);
         if (thread.CancellationToken.IsCancellationRequested)
         {
-            LoggingService.DebugLog($"[UnityHelpService] Task cancelled for Channel {thread.ThreadId}");
+            LoggingService.DebugLog($"[{ServiceName}] Task cancelled for Channel {thread.ThreadId}");
             return Task.FromResult(true);
         }
         return Task.FromResult(false);

--- a/DiscordBot/Services/UserService.cs
+++ b/DiscordBot/Services/UserService.cs
@@ -392,10 +392,8 @@ new("^(?<CodeBlock>`{3}((?<CS>\\w*?$)|$).+?({.+?}).+?`{3})", RegexOptions.Multil
 
             profileCardPath = $"{_settings.ServerRootPath}/images/profiles/{user.Username}-profile.png";
 
-            using (var result = profileCard.Mosaic())
-            {
-                result.Write(profileCardPath);
-            }
+            using var result = profileCard.Mosaic();
+            result.Write(profileCardPath);
         }
         catch (Exception e)
         {

--- a/DiscordBot/Services/UserService.cs
+++ b/DiscordBot/Services/UserService.cs
@@ -165,13 +165,13 @@ new("^(?<CodeBlock>`{3}((?<CS>\\w*?$)|$).+?({.+?}).+?`{3})", RegexOptions.Multil
             var timeStayed = DateTime.Now - joinDate;
             await _loggingService.LogAction(
                 $"User Left - After {(timeStayed.Days > 1 ? Math.Floor((double)timeStayed.Days) + " days" : " ")}" +
-                $" {Math.Floor((double)timeStayed.Hours).ToString(CultureInfo.InvariantCulture)} hours {user.Mention} - `{guildUser.UserNameReference()}` - ID : `{user.Id}`");
+                $" {Math.Floor((double)timeStayed.Hours).ToString(CultureInfo.InvariantCulture)} hours {user.Mention} - `{guildUser.GetPreferredAndUsername()}` - ID : `{user.Id}`");
         }
         // If bot is to slow to get user info, we just say they left at current time.
         else
         {
             await _loggingService.LogAction(
-                $"User `{guildUser.UserNameReference()}` - ID : `{user.Id}` - Left at {DateTime.Now}");
+                $"User `{guildUser.GetPreferredAndUsername()}` - ID : `{user.Id}` - Left at {DateTime.Now}");
         }
     }
 
@@ -336,7 +336,7 @@ new("^(?<CodeBlock>`{3}((?<CS>\\w*?$)|$).+?({.+?}).+?`{3})", RegexOptions.Multil
                 MaxXpShown = maxXpShown,
                 Nickname = ((IGuildUser)user).Nickname,
                 UserId = ulong.Parse(userData.UserID),
-                Username = user.UserNameReference(),
+                Username = user.GetPreferredAndUsername(),
                 XpHigh = xpHigh,
                 XpLow = xpLow,
                 XpPercentage = percentage,
@@ -413,14 +413,14 @@ new("^(?<CodeBlock>`{3}((?<CS>\\w*?$)|$).+?({.+?}).+?`{3})", RegexOptions.Multil
         string icon = user.GetAvatarUrl();
         icon = string.IsNullOrEmpty(icon) ? "https://cdn.discordapp.com/embed/avatars/0.png" : icon;
         
-        string welcomeString = $"Welcome to Unity Developer Community {user.UserNameReferenceForEmbed()}!";
+        string welcomeString = $"Welcome to Unity Developer Community {user.GetPreferredAndUsername()}!";
         var builder = new EmbedBuilder()
             .WithDescription(welcomeString)
             .WithColor(_welcomeColour)
             .WithAuthor(author =>
             {
                 author
-                    .WithName(user.Username)
+                    .WithName(user.Nickname)
                     .WithIconUrl(icon);
             });
 
@@ -653,7 +653,7 @@ new("^(?<CodeBlock>`{3}((?<CS>\\w*?$)|$).+?({.+?}).+?`{3})", RegexOptions.Multil
             {
                 await user.AddRoleAsync(socketTextChannel?.Guild.GetRole(_settings.MutedRoleId));
                 await _loggingService.LogAction(
-                    $"Currently muted user rejoined - {user.Mention} - `{user.UserNameReference()}` - ID : `{user.Id}`");
+                    $"Currently muted user rejoined - {user.Mention} - `{user.GetPreferredAndUsername()}` - ID : `{user.Id}`");
                 if (socketTextChannel != null)
                     await socketTextChannel.SendMessageAsync(
                         $"{user.Mention} tried to rejoin the server to avoid their mute. Mute time increased by 72 hours.");
@@ -663,7 +663,7 @@ new("^(?<CodeBlock>`{3}((?<CS>\\w*?$)|$).+?({.+?}).+?`{3})", RegexOptions.Multil
         }
 
         await _loggingService.LogAction(
-            $"User Joined - {user.Mention} - `{user.UserNameReference()}` - ID : `{user.Id}`");
+            $"User Joined - {user.Mention} - `{user.GetPreferredAndUsername()}` - ID : `{user.Id}`");
 
         // We check if they're already in the welcome list, if they are we don't add them again to avoid double posts
         if (_welcomeNoticeUsers.Count == 0 || !_welcomeNoticeUsers.Exists(u => u.id == user.Id))
@@ -768,8 +768,8 @@ new("^(?<CodeBlock>`{3}((?<CS>\\w*?$)|$).+?({.+?}).+?`{3})", RegexOptions.Multil
         if (oldUser.Nickname != user.Nickname)
         {
             await _loggingService.LogAction(
-                $"User {oldUser.UserNameReference()} changed his " +
-                $"username to {user.UserNameReference()}");
+                $"User {oldUser.GetUserPreferredName()} changed his " +
+                $"username to {user.GetUserPreferredName()}");
         }
     }
 

--- a/DiscordBot/Services/UserService.cs
+++ b/DiscordBot/Services/UserService.cs
@@ -165,13 +165,13 @@ new("^(?<CodeBlock>`{3}((?<CS>\\w*?$)|$).+?({.+?}).+?`{3})", RegexOptions.Multil
             var timeStayed = DateTime.Now - joinDate;
             await _loggingService.LogAction(
                 $"User Left - After {(timeStayed.Days > 1 ? Math.Floor((double)timeStayed.Days) + " days" : " ")}" +
-                $" {Math.Floor((double)timeStayed.Hours).ToString(CultureInfo.InvariantCulture)} hours {user.Mention} - `{user.Username}#{user.DiscriminatorValue}` - ID : `{user.Id}`");
+                $" {Math.Floor((double)timeStayed.Hours).ToString(CultureInfo.InvariantCulture)} hours {user.Mention} - `{guildUser.UserNameReference()}` - ID : `{user.Id}`");
         }
         // If bot is to slow to get user info, we just say they left at current time.
         else
         {
             await _loggingService.LogAction(
-                $"User `{user.Username}#{user.DiscriminatorValue}` - ID : `{user.Id}` - Left at {DateTime.Now}");
+                $"User `{guildUser.UserNameReference()}` - ID : `{user.Id}` - Left at {DateTime.Now}");
         }
     }
 
@@ -336,7 +336,7 @@ new("^(?<CodeBlock>`{3}((?<CS>\\w*?$)|$).+?({.+?}).+?`{3})", RegexOptions.Multil
                 MaxXpShown = maxXpShown,
                 Nickname = ((IGuildUser)user).Nickname,
                 UserId = ulong.Parse(userData.UserID),
-                Username = user.Username,
+                Username = user.UserNameReference(),
                 XpHigh = xpHigh,
                 XpLow = xpLow,
                 XpPercentage = percentage,
@@ -412,9 +412,10 @@ new("^(?<CodeBlock>`{3}((?<CS>\\w*?$)|$).+?({.+?}).+?`{3})", RegexOptions.Multil
     {
         string icon = user.GetAvatarUrl();
         icon = string.IsNullOrEmpty(icon) ? "https://cdn.discordapp.com/embed/avatars/0.png" : icon;
-
+        
+        string welcomeString = $"Welcome to Unity Developer Community {user.UserNameReferenceForEmbed()}!";
         var builder = new EmbedBuilder()
-            .WithDescription($"Welcome to Unity Developer Community **{user.Username}#{user.Discriminator}**!")
+            .WithDescription(welcomeString)
             .WithColor(_welcomeColour)
             .WithAuthor(author =>
             {
@@ -652,7 +653,7 @@ new("^(?<CodeBlock>`{3}((?<CS>\\w*?$)|$).+?({.+?}).+?`{3})", RegexOptions.Multil
             {
                 await user.AddRoleAsync(socketTextChannel?.Guild.GetRole(_settings.MutedRoleId));
                 await _loggingService.LogAction(
-                    $"Currently muted user rejoined - {user.Mention} - `{user.Username}#{user.DiscriminatorValue}` - ID : `{user.Id}`");
+                    $"Currently muted user rejoined - {user.Mention} - `{user.UserNameReference()}` - ID : `{user.Id}`");
                 if (socketTextChannel != null)
                     await socketTextChannel.SendMessageAsync(
                         $"{user.Mention} tried to rejoin the server to avoid their mute. Mute time increased by 72 hours.");
@@ -662,7 +663,7 @@ new("^(?<CodeBlock>`{3}((?<CS>\\w*?$)|$).+?({.+?}).+?`{3})", RegexOptions.Multil
         }
 
         await _loggingService.LogAction(
-            $"User Joined - {user.Mention} - `{user.Username}#{user.DiscriminatorValue}` - ID : `{user.Id}`");
+            $"User Joined - {user.Mention} - `{user.UserNameReference()}` - ID : `{user.Id}`");
 
         // We check if they're already in the welcome list, if they are we don't add them again to avoid double posts
         if (_welcomeNoticeUsers.Count == 0 || !_welcomeNoticeUsers.Exists(u => u.id == user.Id))
@@ -767,8 +768,8 @@ new("^(?<CodeBlock>`{3}((?<CS>\\w*?$)|$).+?({.+?}).+?`{3})", RegexOptions.Multil
         if (oldUser.Nickname != user.Nickname)
         {
             await _loggingService.LogAction(
-                $"User {oldUser.Nickname ?? oldUser.Username}#{oldUser.DiscriminatorValue} changed his " +
-                $"username to {user.Nickname ?? user.Username}#{user.DiscriminatorValue}");
+                $"User {oldUser.UserNameReference()} changed his " +
+                $"username to {user.UserNameReference()}");
         }
     }
 

--- a/DiscordBot/Services/UserService.cs
+++ b/DiscordBot/Services/UserService.cs
@@ -708,11 +708,11 @@ new("^(?<CodeBlock>`{3}((?<CS>\\w*?$)|$).+?({.+?}).+?`{3})", RegexOptions.Multil
             if (_welcomeNoticeUsers.Count > 200)
             {
                 _welcomeNoticeUsers.Clear();
-                await _loggingService.LogAction($"UserService: Welcome list cleared due to size (+200), this should not happen.", true, true);
+                await _loggingService.LogAction("UserService: Welcome list cleared due to size (+200), this should not happen.", true, true);
             }
 
             if (firstRun)
-                await _loggingService.LogAction($"UserService: Welcome service failed on first run!? This should not happen.", true, true);
+                await _loggingService.LogAction("UserService: Welcome service failed on first run!? This should not happen.", true, true);
 
             // Run the service again.
             Task.Run(DelayedWelcomeService);

--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -27,6 +27,12 @@ public class BotSettings
 
     #endregion // Fun Commands
 
+    #region Service Enabling
+    // Used for enabling/disabling services in the bot
+    public bool UnityHelpBabySitterEnabled { get; set; } = false;
+
+    #endregion // Service Enabling
+
     #endregion // Configuration
 
     #region Asset Publisher
@@ -54,9 +60,6 @@ public class BotSettings
     public RulesChannel RulesChannel { get; set; }
 
     // Recruitment Channels
-    public WorkForHireChannel LookingToHire { get; set; }
-    public WorkForHireChannel LookingForWork { get; set; }
-    public CollaborationChannel CollaborationChannel { get; set; }
     
     public ChannelInfo ReportedMessageChannel { get; set; }
     
@@ -193,11 +196,6 @@ public class UnityReleasesChannel : ChannelInfo
 {
 }
 
-public class WorkForHireChannel : ChannelInfo
-{
-}
-
-public class CollaborationChannel : ChannelInfo
 {
 }
 

--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -97,7 +97,7 @@ public class BotSettings
 
     #endregion // User Roles
 
-    #region Recruitment Thread Tags
+    #region Recruitment Thread
     
     public string TagLookingToHire { get; set; }
     public string TagLookingForWork { get; set; }

--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -29,6 +29,9 @@ public class BotSettings
 
     #region Service Enabling
     // Used for enabling/disabling services in the bot
+    
+    public bool RecruitmentServiceEnabled { get; set; } = false;
+
     public bool UnityHelpBabySitterEnabled { get; set; } = false;
 
     #endregion // Service Enabling
@@ -61,6 +64,8 @@ public class BotSettings
 
     // Recruitment Channels
     
+    public RecruitmentChannel RecruitmentChannel { get; set; }
+
     public ChannelInfo ReportedMessageChannel { get; set; }
     
     #region Complaint Channel
@@ -91,6 +96,15 @@ public class BotSettings
     public ulong ModeratorRoleId { get; set; }
 
     #endregion // User Roles
+
+    #region Recruitment Thread Tags
+    
+    public string TagLookingToHire { get; set; }
+    public string TagLookingForWork { get; set; }
+    public string TagUnpaidCollab { get; set; }
+    public string TagPositionFilled { get; set; }
+
+    #endregion // Recruitment Thread Tags
 
     #region API Keys
 
@@ -196,6 +210,7 @@ public class UnityReleasesChannel : ChannelInfo
 {
 }
 
+public class RecruitmentChannel : ChannelInfo
 {
 }
 

--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -103,6 +103,8 @@ public class BotSettings
     public string TagLookingForWork { get; set; }
     public string TagUnpaidCollab { get; set; }
     public string TagPositionFilled { get; set; }
+    
+    public int EditPermissionAccessTimeMin { get; set; } = 3;
 
     #endregion // Recruitment Thread Tags
 

--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -34,6 +34,8 @@ public class BotSettings
 
     public bool UnityHelpBabySitterEnabled { get; set; } = false;
 
+    public bool ReactRoleServiceEnabled { get; set; } = false;
+
     #endregion // Service Enabling
 
     #endregion // Configuration

--- a/DiscordBot/Settings/Settings.example.json
+++ b/DiscordBot/Settings/Settings.example.json
@@ -93,8 +93,11 @@
   "EditPermissionAccessTimeMin": 3,
   /* Unity Help Service */
   "UnityHelpBabySitterEnabled": false,
-  "genericHelpChannel": { // Unity-help
+  "genericHelpChannel": {
+    // Unity-help
     "desc": "Unity-Help Channel",
     "id": "0"
-  }
+  },
+  /* React Role Service */
+  "ReactRoleServiceEnabled": false
 }

--- a/DiscordBot/Settings/Settings.example.json
+++ b/DiscordBot/Settings/Settings.example.json
@@ -56,18 +56,6 @@
     "desc": "Unity News Channel",
     "id": "0"
   },
-  "LookingToHire": {
-    "desc": "Looking To Hire Channel",
-    "id": "0" // Currently Unused 29/04/21
-  },
-  "LookingForWork": {
-    "desc": "Looking For Work Channel",
-    "id": "0" // Currently Unused 29/04/21
-  },
-  "CollaborationChannel": {
-    "desc": "Collaboration Channel",
-    "id": "0" // Currently Unused 29/04/21
-  },
   "ReportedMessageChannel": {
     "desc": "Reported Message Channel",
     "id": "0"
@@ -91,5 +79,22 @@
   "WeatherAPIKey": "", // Key for openweathermap.org
   "FlightAPIKey": "",
   "FlightAPISecret": "",
-  "AirLabAPIKey": ""
+  "AirLabAPIKey": "",
+  /* Recruitment Service */
+  "RecruitmentServiceEnabled": false,
+  "RecruitmentChannel": { // Recruitment
+    "desc": "Channel for job postings",
+    "id": "0"
+  },
+  "TagLookingToHire": "0",
+  "TagLookingForWork": "0",
+  "TagUnpaidCollab": "0",
+  "TagPositionFilled": "0",
+  "EditPermissionAccessTimeMin": 3,
+  /* Unity Help Service */
+  "UnityHelpBabySitterEnabled": false,
+  "genericHelpChannel": { // Unity-help
+    "desc": "Unity-Help Channel",
+    "id": "0"
+  }
 }

--- a/DiscordBot/Utils/StringUtil.cs
+++ b/DiscordBot/Utils/StringUtil.cs
@@ -1,0 +1,21 @@
+using System.Text.RegularExpressions;
+
+namespace DiscordBot.Utils;
+
+public static class StringUtil
+{
+    private static readonly Regex CurrencyRegex =
+        new Regex(@"(?:\$\s*\d+|\d+\s*\$|\d*\s*(?:USD|£|pounds|€|EUR|euro|euros|GBP))", RegexOptions.IgnoreCase);
+    private static readonly Regex RevShareRegex = new Regex(@"\b(?:rev-share|revshare|rev share)\b");
+    
+    // a string extension that checks if the contents of the string contains a limited selection of currency symbols/words
+    public static bool ContainsCurrencySymbol(this string str)
+    {
+        return !string.IsNullOrWhiteSpace(str) && CurrencyRegex.IsMatch(str);
+    }
+    
+    public static bool ContainsRevShare(this string str)
+    {
+        return !string.IsNullOrWhiteSpace(str) && RevShareRegex.IsMatch(str);
+    }
+}

--- a/DiscordBot/Utils/StringUtil.cs
+++ b/DiscordBot/Utils/StringUtil.cs
@@ -5,8 +5,8 @@ namespace DiscordBot.Utils;
 public static class StringUtil
 {
     private static readonly Regex CurrencyRegex =
-        new Regex(@"(?:\$\s*\d+|\d+\s*\$|\d*\s*(?:USD|£|pounds|€|EUR|euro|euros|GBP))", RegexOptions.IgnoreCase);
-    private static readonly Regex RevShareRegex = new Regex(@"\b(?:rev-share|revshare|rev share)\b");
+        new (@"(?:\$\s*\d+|\d+\s*\$|\d*\s*(?:USD|£|pounds|€|EUR|euro|euros|GBP))", RegexOptions.IgnoreCase);
+    private static readonly Regex RevShareRegex = new (@"\b(?:rev-share|revshare|rev share)\b");
     
     // a string extension that checks if the contents of the string contains a limited selection of currency symbols/words
     public static bool ContainsCurrencySymbol(this string str)

--- a/DiscordBot/Utils/StringUtil.cs
+++ b/DiscordBot/Utils/StringUtil.cs
@@ -5,8 +5,8 @@ namespace DiscordBot.Utils;
 public static class StringUtil
 {
     private static readonly Regex CurrencyRegex =
-        new (@"(?:\$\s*\d+|\d+\s*\$|\d*\s*(?:USD|£|pounds|€|EUR|euro|euros|GBP))", RegexOptions.IgnoreCase);
-    private static readonly Regex RevShareRegex = new (@"\b(?:rev-share|revshare|rev share)\b");
+        new (@"(?:\$\s*\d+|\d+\s*\$|\d*\s*(?:USD|£|pounds|€|EUR|euro|euros|GBP))", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(250));
+    private static readonly Regex RevShareRegex = new (@"\b(?:rev-share|revshare|rev share)\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(250));
     
     // a string extension that checks if the contents of the string contains a limited selection of currency symbols/words
     public static bool ContainsCurrencySymbol(this string str)

--- a/DiscordBot/Utils/StringUtil.cs
+++ b/DiscordBot/Utils/StringUtil.cs
@@ -18,4 +18,10 @@ public static class StringUtil
     {
         return !string.IsNullOrWhiteSpace(str) && RevShareRegex.IsMatch(str);
     }
+
+    public static string MessageSelfDestructIn(int secondsFromNow)
+    {
+        var time = DateTime.Now.ToUnixTimestamp() + secondsFromNow;
+        return $"Self-delete: **<t:{time}:R>**";
+    }
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The code is provided as-is and there will be no guaranteed support to help make 
     - [Docker](#docker)
     - [Runtime Dependencies](#runtime-dependencies)
 - [Notes](#notes)
+    - [Logging](#logging)
+    - [Discord.Net](#discordnet)
 - [FAQ](#faq)
 
 ## Compiling
@@ -63,12 +65,16 @@ On Linux you might need `sudo apt install ttf-mscorefonts-installer` for ImageMa
 
 ## Notes
 
-I'll re-introduce some of this later.
-~~When you hit run, you'll probably see some warnings and errors if you've sped through this without much thought.~~
-~~- **_Yellow_** : Warnings _(The bot will continue to run, but may disable some features)_~~
-~~- **_Red_** : Errors _(Usually a pending exception/crash is moments away)_~~
+### Logging
 
-I strongly suggest giving [Discord.Net API Documention](https://discord.foxbot.me/stable/api/index.html) a read when interacting with systems you haven't seen before. Discord Net uses Tasks, Asynchronous Patterns and heavy use of Polymorphism, some systems might not always be straight forward.
+The bot does attempt to log issues it runs into during startup, not everything is covered yet and a lot of it is stripped from the release build. 
+A basic Enum is used, Critical/Error uses Red, Warning uses Yellow, Info is White and Verbose/Debug is Gray. ([LoggingService](https://github.com/Unity-Developer-Community/UDC-Bot/blob/dev/DiscordBot/Services/LoggingService.cs#L71))
+
+During startup, if you see any yellow/red, good chance something is wrong.
+
+### Discord.Net
+
+I strongly suggest giving [Discord.Net API Documention](https://discordnet.dev/guides/introduction/intro.html) a read when interacting with systems you haven't seen before. Discord Net uses Tasks, Asynchronous Patterns and heavy use of Polymorphism, some systems might not always be straight forward.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,27 @@ Join us on [Discord](https://discord.gg/bu3bbby) !
 
 The code is provided as-is and there will be no guaranteed support to help make it run.
 
+# Table Of Contents
+<!-- Link to all the headers -->
+- [Compiling](#compiling)
+  - [Dependencies](#dependencies)
+- [Running](#running)
+    - [Docker](#docker)
+    - [Runtime Dependencies](#runtime-dependencies)
+- [Notes](#notes)
+- [FAQ](#faq)
+
 ## Compiling
 
 ### Dependencies
 
 To successfully compile you will need the following.
-
 - [Discord.Net](https://www.nuget.org/packages/Discord.Net/)
-- [Visual Studio](https://visualstudio.microsoft.com/vs/community/)
+- [Visual Studio](https://visualstudio.microsoft.com/vs/community/) (or IDE of choice)
 - [.NET Core SDK](https://www.microsoft.com/net/download/core)
+- [Docker](https://www.docker.com/get-started) (Optional, but recommended)
+
+>NOTE: It is highly recommended to install docker and docker-compose to run at least the database in a container for local development.
 
 ## Running
 
@@ -28,9 +40,15 @@ _Several comments have been placed throughout the settings file to indicate what
 
 _If you plan on running the bot outside of the IDE, you will want to give [Discord Net Deployment](https://discord.foxbot.me/docs/guides/deployment/deployment.html) a read._
 
+### Docker
+Running docker should be as simple as running `docker-compose up` in the root directory of the project. This will use the docker-compose.yml file to build the bot and database images and run them. You may need to change the DbConnectionString in the [settings.json](https://github.com/Unity-Developer-Community/UDC-Bot/tree/dev/DiscordBot/Settings) file to match the docker-compose.yml file configuration.
+
+> Note: Docker will also create an image of the bot, it may be much quicker to run the bot yourself from the IDE if you're making changes. 
+> You can also use `docker-compose up --build` to force a rebuild of the bot image, but I would advise to disable the bot in the docker-compose.yml file, and run the bot from the IDE.
+
 ### Runtime Dependencies
 
-You will need an accessible SQL database setup, the easiest way to do this is using XAMPP which can host the database and make it easier to setup.
+If you choose to not use docker, you will need to host the database yourself and ensure the bot can connect to it. You will need an accessible SQL database setup, the easiest way to do this is using XAMPP which can host the database and make it easier to setup.
 
 - [XAMPP](https://www.apachefriends.org/download.html)
 


### PR DESCRIPTION
### Description 📝
Fairly basic clean-up of the repo, a number of simple fixes have been applied.
- Added some additional information to the ReadMe regarding Docker and getting the project to run, and remove other misc details that had long since been abandoned.
 - Replaced use of Discriminator with DisplayName "NickName (aka Username)" where possible, otherwise use of DisplayName (which will show NickName as preference, with Username shown if no Nick)
 - Added some additional checks during database startup to prevent some issues with docker
 - Track Deleted and Edited messages better, smaller format, include edited messages if still exists in cached results, but also includes a small message any time a message is edited to maintain proof of change if required.
- Introduced a Bool in the settings to easily enable/disable the previously merged UnityHelp BabySitter service so that if it doesn't work as intended after all this time since implementation, it can at least be disabled without rolling-back.
- Expanded Logger enum to support some of our own Severity types, mostly for debugging but a green "Positive" and a darker yellow "LowWarning" for more ignorable issues.
- Fix issues (hopefully) with the Welcome service
- Add settings for UserRoleService which we don't use so it uses less processing and doesn't latch into more gateway events.
- Added a utility method to see the ID of tags in forum posts so that they're easier to identify. Discord doesn't give us a way to see these without bot assistance. 

**Big Changes**
- RecruitmentService made to babysit the recruitment channel, it opperates under the expectation that deleting messages is fair-game and that failure to meet guidelines is deletable. It follows pretty simple rules, with 2 main regex checks for new threads in the relevant channels.

Match Currency: `(?:\$\s*\d+|\d+\s*\$|\d*\s*(?:USD|£|pounds|€|EUR|euro|euros|GBP))`
Was Rev-Share mentioned: `\b(?:rev-share|revshare|rev share)\b`

Rev-Share isn't a "deletable" offense if a price was included in the message, but I feel the notice alone should help guide users to make decisions better. ie; avoid potential rev-share.

I've included some screenshots of basic intended functionality, however the wording of some of these have changed to be more straight forward.
![Discord_4Uxev174WR](https://github.com/Unity-Developer-Community/UDC-Bot/assets/8342701/acf6536a-ac5c-4b3f-8a9e-c436ac1128b5)
![Discord_nWY13gIjJZ](https://github.com/Unity-Developer-Community/UDC-Bot/assets/8342701/8bedbdbc-a9fb-46ce-8b48-123c65cbd1c6)
![Discord_SpMS2pqbx8](https://github.com/Unity-Developer-Community/UDC-Bot/assets/8342701/0faf874a-abe6-44a7-b47e-b96d135ba847)
![Discord_0aCbBrGDwQ](https://github.com/Unity-Developer-Community/UDC-Bot/assets/8342701/b9a991c4-5d6d-40be-bb32-04ccad4d3e4a)


### Link to Issue🔗
#212