### PR TITLE
Feat: Misc Fixes & Recruitment Service

### DIFF
--- a/DiscordBot/Extensions/UserExtensions.cs
+++ b/DiscordBot/Extensions/UserExtensions.cs
@@ -15,7 +15,10 @@ public static class UserExtensions
     }
     public static bool HasRoleGroup(this IUser user, ulong roleId)
     {
-        return user is SocketGuildUser guildUser && guildUser.Roles.Any(x => x.Id == roleId);
+        var guildUser = user as IGuildUser;
+        if (guildUser == null)
+            return false;
+        return guildUser.RoleIds.Any(x => x == roleId);
     }
 
     // Returns the users DisplayName (nickname) if it exists, otherwise returns the username

--- a/DiscordBot/Program.cs
+++ b/DiscordBot/Program.cs
@@ -24,6 +24,7 @@ public class Program
     private IServiceProvider _services;
 
     private UnityHelpService _unityHelpService;
+    private RecruitService _recruitService;
 
     public static void Main(string[] args) =>
         new Program().MainAsync().GetAwaiter().GetResult();
@@ -68,7 +69,7 @@ public class Program
                 _isInitialized = true;
                 
                 _unityHelpService = _services.GetRequiredService<UnityHelpService>();
-                _services.GetRequiredService<RecruitService>();
+                _recruitService = _services.GetRequiredService<RecruitService>();
             }
             return Task.CompletedTask;
         };

--- a/DiscordBot/Services/Recruitment/RecruitService.cs
+++ b/DiscordBot/Services/Recruitment/RecruitService.cs
@@ -29,7 +29,7 @@ public class RecruitService
     private Color WarningMessageColor => new (255, 255, 100);
     private Color EditedMessageColor => new (100, 255, 100);
 
-    private const int TimeBeforeDeletingForumInSec = 30;
+    private const int TimeBeforeDeletingForumInSec = 60;
     private const string _messageToBeDeleted = "Your thread will be deleted in %s because it did not follow the expected guidelines. Try again after the slow mode period has passed.";
     
     private const int MinimumLengthMessage = 120;
@@ -263,7 +263,7 @@ public class RecruitService
         await parentChannel.AddPermissionOverwriteAsync(thread.Owner, new OverwritePermissions(sendMessages: PermValue.Allow));
         
         // We give them a bit of time to edit their post, then remove the permission
-        await message.DeleteAfterSeconds((_editTimePermissionInMin * 60) + 5);
+        await message.DeleteAfterSeconds((_editTimePermissionInMin * 60) + 2);
         await parentChannel.RemovePermissionOverwriteAsync(thread.Owner);
         
         // Lock the thread so anyone else can't post even when they have edit permissions

--- a/DiscordBot/Services/Recruitment/RecruitService.cs
+++ b/DiscordBot/Services/Recruitment/RecruitService.cs
@@ -138,7 +138,7 @@ public class RecruitService
 
         Task.Run(async () =>
         {
-            if (thread.AppliedTags.Count == 0)
+            if (!DoesThreadHaveAValidTag(thread))
             {
                 await ThreadHandleNoTags(thread);
                 return;
@@ -346,6 +346,12 @@ public class RecruitService
         if (tags.Contains(_tagUnpaidCollab.Id)) clashingTagCount++;
         
         return clashingTagCount > 1;
+    }
+
+    private bool DoesThreadHaveAValidTag(SocketThreadChannel thread)
+    {
+        var tags = thread.AppliedTags;
+        return tags.Contains(_tagIsHiring.Id) || tags.Contains(_tagWantsWork.Id) || tags.Contains(_tagUnpaidCollab.Id);
     }
     
     private async Task DeleteThread(SocketThreadChannel thread)

--- a/DiscordBot/Services/ReminderService.cs
+++ b/DiscordBot/Services/ReminderService.cs
@@ -28,8 +28,8 @@ public class ReminderService
     private readonly BotCommandsChannel _botCommandsChannel;
     private bool _hasChangedSinceLastSave = false;
 
-    private int _maxUserReminders = 5;
-        
+    private const int _maxUserReminders = 10;
+
     public ReminderService(DiscordSocketClient client, ILoggingService loggingService, BotSettings settings)
     {
         _client = client;

--- a/DiscordBot/Services/ReminderService.cs
+++ b/DiscordBot/Services/ReminderService.cs
@@ -160,7 +160,9 @@ public class ReminderService
                     // If channel is null we get the bot command channel, and send the message there
                     channel ??= _client.GetChannel(_botCommandsChannel.Id) as SocketTextChannel;
                     var user = _client.GetUser(reminder.UserId);
-                    if (user != null)
+                    if (user == null) continue;
+                    
+                    if (channel != null)
                         await channel.SendMessageAsync(
                             $"{user.Mention} reminder: \"{reminder.Message}\"");
                 }

--- a/DiscordBot/Utils/StringUtil.cs
+++ b/DiscordBot/Utils/StringUtil.cs
@@ -5,7 +5,7 @@ namespace DiscordBot.Utils;
 public static class StringUtil
 {
     private static readonly Regex CurrencyRegex =
-        new (@"(?:\$\s*\d+|\d+\s*\$|\d*\s*(?:USD|£|pounds|€|EUR|euro|euros|GBP))", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(250));
+        new (@"(?:\$\s*\d+|\d+\s*\$|\d*\s*(?:USD|£|pounds|€|EUR|euro|euros|GBP|円|YEN))", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(250));
     private static readonly Regex RevShareRegex = new (@"\b(?:rev-share|revshare|rev share)\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(250));
     
     // a string extension that checks if the contents of the string contains a limited selection of currency symbols/words


### PR DESCRIPTION
### Description 📝
Continued clean-up, and fix a couple small issues introduced by recuirtment service.
- Fix issue with Recruitment ignoring any tags, not just ones we want
- Fix issue with rolegroup identifier not returning correct result
- Fix bug introduced from deprecated xml reader
- Impr: RecruitService locks a channel after the edit period has passed
- Impr: Increase max reminders to 10 for the crazy people
- Impr: RecruitmentService will delete any messages by non-mods in recruitment channels to prevent cross-post while editing is active.

### Link to Issue🔗
#212