### PR TITLE
More flexible arguments in TipModule.cs

### DIFF
--- a/DiscordBot/Modules/TipModule.cs
+++ b/DiscordBot/Modules/TipModule.cs
@@ -213,11 +213,11 @@ public class TipModule : ModuleBase
 			int chunk = 0;
 			while (tips.Count > 0 && chunk < chunkCount)
    			{
-				string keywords = string.Join("`, `", tips[0].Keywords.OrderBy(k => k));
+				string keywordlist = string.Join("`, `", tips[0].Keywords.OrderBy(k => k));
 				string images = String.Concat(
     					Enumerable.Repeat(" :frame_photo:",
 	 				tips[0].ImagePaths.Count).ToArray());
-				builder.AddField($"ID: {tips[0].Id} {images}", $"`{keywords}`");
+				builder.AddField($"ID: {tips[0].Id} {images}", $"`{keywordlist}`");
 				tips.RemoveAt(0);
 				chunk++;
 			}


### PR DESCRIPTION
Instead of taking one argument which must be a comma-joined list of keywords, now !tip can take any number of space- or comma-joined keyword arguments.

Identical:
!tip left,outer,join (old requirement 1 argument)
!tip left,outer join
!tip left outer join (now, probably most natural)
