### PR TITLE
Better publisher validation email PublisherService.cs

### DIFF
--- a/DiscordBot/Services/PublisherService.cs
+++ b/DiscordBot/Services/PublisherService.cs
@@ -60,15 +60,25 @@ public class PublisherService
 
         var code = Convert.ToBase64String(random);
 
+		var body = string.Join('\n', new string[] {
+			$"Somebody named @{name} on the Unity Developer Community Discord server " +
+			"has requested the Publisher role on that server.",
+			"",
+			$"Here's your validation code: {code}",
+			"",
+			"If this is you, enter the command '!verify {packageID} {code}' to complete the process.",
+			"",
+			"If this is NOT you, feel free to join the UDC Discord server " +
+			"to report @{name} to the @Administrators (and join our community if you like).",
+			"https://discord.gg/bu3bbby",
+		};
+
         _verificationCodes[packageId] = code;
         var message = new MimeMessage();
         message.From.Add(new MailboxAddress("Unity Developer Community", _settings.Email));
         message.To.Add(new MailboxAddress(name, email));
         message.Subject = "Unity Developer Community Package Validation";
-        message.Body = new TextPart("plain")
-        {
-            Text = @"Here's your validation code : " + code
-        };
+        message.Body = new TextPart("plain") { Text = body };
 
         using (var client = new SmtpClient())
         {

--- a/DiscordBot/Services/PublisherService.cs
+++ b/DiscordBot/Services/PublisherService.cs
@@ -66,10 +66,10 @@ public class PublisherService
 			"",
 			$"Here's your validation code: {code}",
 			"",
-			"If this is you, enter the command '!verify {packageID} {code}' to complete the process.",
+			$"If this is you, enter the command '!verify {packageID} {code}' to complete the process.",
 			"",
 			"If this is NOT you, feel free to join the UDC Discord server " +
-			"to report @{name} to the @Administrators (and join our community if you like).",
+			$"to report @{name} to the @Administrators (and join our community if you like).",
 			"https://discord.gg/bu3bbby"
 		});
 

--- a/DiscordBot/Services/PublisherService.cs
+++ b/DiscordBot/Services/PublisherService.cs
@@ -66,7 +66,7 @@ public class PublisherService
 			"",
 			$"Here's your validation code: {code}",
 			"",
-			$"If this is you, enter the command '!verify {packageID} {code}' to complete the process.",
+			$"If this is you, enter the command '!verify {packageId} {code}' to complete the process.",
 			"",
 			"If this is NOT you, feel free to join the UDC Discord server " +
 			$"to report @{name} to the @Administrators (and join our community if you like).",

--- a/DiscordBot/Services/PublisherService.cs
+++ b/DiscordBot/Services/PublisherService.cs
@@ -70,8 +70,8 @@ public class PublisherService
 			"",
 			"If this is NOT you, feel free to join the UDC Discord server " +
 			"to report @{name} to the @Administrators (and join our community if you like).",
-			"https://discord.gg/bu3bbby",
-		};
+			"https://discord.gg/bu3bbby"
+		});
 
         _verificationCodes[packageId] = code;
         var message = new MimeMessage();


### PR DESCRIPTION
Potential alternative to Issue 58
https://github.com/Unity-Developer-Community/UDC-Bot/issues/58

We have a lot of existing @Publishers with no database to associate them with the packageID they published.

Instead of relying on a database of publisher/package IDs, we offer an improved publisher validation email that explains how a real publisher can fight back against spam (if it's happening).