### PR TITLE
Fix daily reward eligibility to use configurable calendar days instead of 24-hour intervals

### DIFF
--- a/DiscordBot/Services/Casino/CasinoService.cs
+++ b/DiscordBot/Services/Casino/CasinoService.cs
@@ -321,7 +321,7 @@ public class CasinoService
         {
             var user = await GetOrCreateCasinoUser(userId);
             var now = DateTime.UtcNow;
-            var nextRewardTime = user.LastDailyReward.AddSeconds(_settings.CasinoDailyRewardIntervalSeconds);
+            var nextRewardTime = user.LastDailyReward.Date.AddDays(1);
 
             if (now < nextRewardTime)
             {
@@ -335,7 +335,7 @@ public class CasinoService
             await RecordTransaction(userId, (long)tokensAwarded, TransactionType.DailyReward);
 
             await _loggingService.LogChannelAndFile($"{ServiceName}: User {userId} claimed daily reward of {tokensAwarded} tokens");
-            return (true, tokensAwarded, newBalance, now.AddSeconds(_settings.CasinoDailyRewardIntervalSeconds));
+            return (true, tokensAwarded, newBalance, now.Date.AddDays(1));
         }
         catch (Exception ex)
         {
@@ -348,7 +348,7 @@ public class CasinoService
     public async Task<DateTime> GetNextDailyRewardTime(string userId)
     {
         var user = await GetOrCreateCasinoUser(userId);
-        return user.LastDailyReward.AddSeconds(_settings.CasinoDailyRewardIntervalSeconds);
+        return user.LastDailyReward.Date.AddDays(1);
     }
 
     #endregion

--- a/DiscordBot/Services/Casino/CasinoService.cs
+++ b/DiscordBot/Services/Casino/CasinoService.cs
@@ -321,7 +321,7 @@ public class CasinoService
         {
             var user = await GetOrCreateCasinoUser(userId);
             var now = DateTime.UtcNow;
-            var nextRewardTime = user.LastDailyReward.Date.AddDays(1);
+            var nextRewardTime = user.LastDailyReward.Date.AddDays(_settings.CasinoDailyRewardIntervalDays);
 
             if (now < nextRewardTime)
             {
@@ -335,7 +335,7 @@ public class CasinoService
             await RecordTransaction(userId, (long)tokensAwarded, TransactionType.DailyReward);
 
             await _loggingService.LogChannelAndFile($"{ServiceName}: User {userId} claimed daily reward of {tokensAwarded} tokens");
-            return (true, tokensAwarded, newBalance, now.Date.AddDays(1));
+            return (true, tokensAwarded, newBalance, now.Date.AddDays(_settings.CasinoDailyRewardIntervalDays));
         }
         catch (Exception ex)
         {
@@ -348,7 +348,7 @@ public class CasinoService
     public async Task<DateTime> GetNextDailyRewardTime(string userId)
     {
         var user = await GetOrCreateCasinoUser(userId);
-        return user.LastDailyReward.Date.AddDays(1);
+        return user.LastDailyReward.Date.AddDays(_settings.CasinoDailyRewardIntervalDays);
     }
 
     #endregion

--- a/DiscordBot/Settings/Deserialized/Settings.cs
+++ b/DiscordBot/Settings/Deserialized/Settings.cs
@@ -166,7 +166,7 @@ public class BotSettings
 
     // Daily Reward Settings
     public ulong CasinoDailyRewardTokens { get; set; } = 100;
-    public int CasinoDailyRewardIntervalSeconds { get; set; } = 86400; // 24 hours = 86400 seconds
+    public int CasinoDailyRewardIntervalDays { get; set; } = 1; // Number of days between rewards
 
     #endregion // Casino Settings
 


### PR DESCRIPTION
This PR updates the daily reward system in `CasinoService` to use calendar day-based eligibility with a configurable interval instead of fixed 24-hour periods.

## Problem

Previously, users had to wait exactly 24 hours from their last daily reward claim before becoming eligible again. This meant:
- A user claiming at 11 PM would have to wait until 11 PM the next day
- Users in different time zones had varying optimal claim times  
- The system felt less intuitive than typical "daily" mechanics
- The interval was hardcoded to 1 day and not configurable by server admins

## Solution

The logic now compares calendar dates instead of time intervals and uses a configurable setting for the number of days:

```csharp
// Before: 24-hour interval from last claim
var nextRewardTime = user.LastDailyReward.AddSeconds(_settings.CasinoDailyRewardIntervalSeconds);

// After: Configurable number of calendar days after last claim
var nextRewardTime = user.LastDailyReward.Date.AddDays(_settings.CasinoDailyRewardIntervalDays);
```

## Changes Made

- **`TryClaimDailyReward`**: Updated eligibility check to use `user.LastDailyReward.Date.AddDays(_settings.CasinoDailyRewardIntervalDays)`
- **`TryClaimDailyReward`**: Updated return value to use `now.Date.AddDays(_settings.CasinoDailyRewardIntervalDays)` for consistent calendar logic
- **`GetNextDailyRewardTime`**: Updated to use configurable interval setting
- **Settings**: Renamed `CasinoDailyRewardIntervalSeconds` to `CasinoDailyRewardIntervalDays` with default value of 1

## Impact

Users can now claim their daily reward once per configurable calendar day period (UTC), providing a more intuitive and flexible experience:
- Claiming at 11 PM allows the next claim at 12 AM (1 hour later) when set to 1 day
- All users become eligible at the same UTC midnight boundary  
- Server admins can configure the interval (e.g., daily=1, every 2 days=2, weekly=7)
- Maintains the "once per period" restriction while improving user experience

This change is backward compatible with existing database schemas and user data.

<!-- START COPILOT CODING AGENT SUFFIX -->

*This pull request was created as a result of the following prompt from Copilot chat.*
> Update TryClaimDailyReward in CasinoService so daily reward eligibility is checked by calendar day instead of interval seconds. Compare now.Date and user.LastDailyReward.Date, and set nextRewardTime to the start of the next calendar day after the last claim. Use nextRewardTime in both the eligibility check and the return value. The updated logic should look like:
> 
> var now = DateTime.UtcNow;
> var nextRewardTime = user.LastDailyReward.Date.AddDays(1);
> if (now < nextRewardTime)
> {
>     // User has already claimed today
>     return (false, 0, user.Tokens, nextRewardTime);
> }
> // User can claim daily reward
> // ... (rest unchanged)
> 
> This ensures users can claim their reward once per calendar day. All usages of the old interval-based logic should be replaced. Target the fork source branch for the PR.
> 
> References:
> https://github.com/caprapaul/UDC-Bot/blob/master/DiscordBot/Services/Casino/CasinoService.cs#L318