### PR TITLE
Add uniqueness to FuzzTable, use it for Slap objects.

### DIFF
--- a/DiscordBot/Data/FuzzTable.cs
+++ b/DiscordBot/Data/FuzzTable.cs
@@ -26,20 +26,28 @@ public class FuzzTable
 	private List<string> choices = new();
 	private Queue<string> recent = new();
 
+	// By default, multiple equal entries adds weight to their selection.
+	// If true, duplicates are rejected silently.
+	//
+	public bool Unique { get; set; } = false;
+
 	public void Clear()
 	{
 		choices.Clear();
 		recent.Clear();
+		Unique = false;
 	}
 
 	public int Count => choices.Count + recent.Count;
 
 	// Add a string as a valid choice from which to pick.
 	// Note that empty strings or whitespace can be added manually as valid choices.
-	// Duplicate choices are also allowed for weighting.
+	// Duplicate choices are also allowed for weighting, unless Unique is set true.
 	//
 	public void Add(string choice)
 	{
+		if (Unique && choices.Contains(choice))
+			return;
 		choices.Add(choice);
 	}
 

--- a/DiscordBot/Modules/UserModule.cs
+++ b/DiscordBot/Modules/UserModule.cs
@@ -623,6 +623,7 @@ public class UserModule : ModuleBase
     {
         try
         {
+            _slapObjects.Unique = true;
             if (_slapObjects.Count == 0)
                 _slapObjects.Load(Settings.UserModuleSlapObjectsTable);
         }


### PR DESCRIPTION
Since the !slap command code has two "fallback" sets of choices, it weighs some duplicate options more heavily.  This adds an optional Unique filtering feature on the FuzzTable and uses it to keep the slap object choices tidy.